### PR TITLE
Add v10 resources schemas

### DIFF
--- a/tap_impact/schemas/action_updates.json
+++ b/tap_impact/schemas/action_updates.json
@@ -24,12 +24,33 @@
     "campaign_id": {
       "type": ["null", "integer"]
     },
+    "catalog_category": {
+      "type": ["null", "string"]
+    },
+    "catalog_description": {
+      "type": ["null", "string"]
+    },
+    "catalog_manufacturer": {
+      "type": ["null", "string"]
+    },
+    "catalog_name": {
+      "type": ["null", "string"]
+    },
+    "catalog_original_format_category": {
+      "type": ["null", "string"]
+    },
+    "catalog_subcategory": {
+      "type": ["null", "string"]
+    },
     "category": {
       "type": ["null", "string"]
     },
     "clearing_date": {
       "type": ["null", "string"],
       "format": "date-time"
+    },
+    "contract_id": {
+      "type": ["null", "string"]
     },
     "currency": {
       "type": ["null", "string"]
@@ -38,6 +59,13 @@
       "type": ["null", "string"]
     },
     "customer_status": {
+      "type": ["null", "string"]
+    },
+    "default_payout": {
+      "type": ["null", "number"],
+      "multipleOf": 1e-8
+    },
+    "default_payout_currency": {
       "type": ["null", "string"]
     },
     "delta_amount": {
@@ -49,6 +77,12 @@
       "multipleOf": 1e-8
     },
     "disposition": {
+      "type": ["null", "string"]
+    },
+    "event_type_id": {
+      "type": ["null", "string"]
+    },
+    "event_type_name": {
       "type": ["null", "string"]
     },
     "id": {
@@ -64,8 +98,11 @@
     "order_id": {
       "type": ["null", "string"]
     },
+    "payout_level": {
+      "type": ["null", "string"]
+    },
     "quantity": {
-      "type": ["null", "integer"]
+      "type": ["null", "string"]
     },
     "shared_id": {
       "type": ["null", "string"]

--- a/tap_impact/schemas/campaigns.json
+++ b/tap_impact/schemas/campaigns.json
@@ -128,7 +128,7 @@
     "id": {
       "type": ["null", "integer"]
     },
-    "identity_collapsing": {
+    "identity_matching": {
       "type": ["null", "string"]
     },
     "impression_tracking": {
@@ -196,7 +196,17 @@
       "type": ["null", "string"]
     },
     "shipping_regions": {
-      "type": ["null", "string"]
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": ["null", "string"]
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "short_description": {
       "type": ["null", "string"]
@@ -215,6 +225,9 @@
     },
     "trademark_bidding": {
       "type": ["null", "boolean"]
+    },
+    "uri": {
+      "type": ["null", "string"]
     },
     "view_through_crediting": {
       "type": ["null", "boolean"]

--- a/tap_impact/schemas/company_information.json
+++ b/tap_impact/schemas/company_information.json
@@ -121,7 +121,7 @@
       "additionalProperties": false,
       "properties": {
         "industry_id": {
-          "type": ["null", "integer"]
+          "type": ["null", "string"]
         },
         "industry_name": {
           "type": ["null", "string"]
@@ -166,7 +166,7 @@
           "type": ["null", "string"]
         },
         "user_id": {
-          "type": ["null", "integer"]
+          "type": ["null", "string"]
         },
         "work_phone_number": {
           "type": ["null", "string"]

--- a/tap_impact/schemas/contacts.json
+++ b/tap_impact/schemas/contacts.json
@@ -11,28 +11,10 @@
             "additionalProperties": false,
             "properties": {
               "id": {
-                "type": ["null", "integer"]
+                "type": ["null", "string"]
               },
               "name": {
                 "type": ["null", "string"]
-              }
-            }
-          }
-        },
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "account": {
-              "type": ["null", "object"],
-              "additionalProperties": false,
-              "properties": {
-                "id": {
-                  "type": ["null", "integer"]
-                },
-                "name": {
-                  "type": ["null", "string"]
-                }
               }
             }
           }
@@ -50,6 +32,9 @@
     },
     "cellphone_number_country": {
       "type": ["null", "string"]
+    },
+    "editable": {
+      "type": ["null", "boolean"]
     },
     "email_address": {
       "type": ["null", "string"]

--- a/tap_impact/schemas/contracts.json
+++ b/tap_impact/schemas/contracts.json
@@ -1,0 +1,632 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "brand_signatory": {
+      "type": ["null", "string"]
+    },
+    "brand_signatory_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "date_created": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "date_last_updated": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "end_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "id": {
+      "type": ["null", "string"]
+    },
+    "partner_id": {
+      "type": ["null", "integer"]
+    },
+    "partner_signatory": {
+      "type": ["null", "string"]
+    },
+    "partner_signatory_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "partner_value1": {
+      "type": ["null", "string"]
+    },
+    "pdf_uri": {
+      "type": ["null", "string"]
+    },
+    "start_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "status": {
+      "type": ["null", "string"]
+    },
+    "template_terms": {
+      "type": ["null", "object"],
+      "additionalProperties": false,
+      "properties": {
+        "action_limit": {
+          "type": ["null", "integer"]
+        },
+        "action_limit_period": {
+          "type": ["null", "string"]
+        },
+        "change_notification_period": {
+          "type": ["null", "integer"]
+        },
+        "contract_start_slotting_fee": {
+          "type": ["null", "number"],
+          "multipleOf": 1e-8
+        },
+        "currency": {
+          "type": ["null", "string"]
+        },
+        "custom_creative_payer": {
+          "type": ["null", "string"]
+        },
+        "events_payouts": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "credit_policy": {
+                    "type": ["null", "string"]
+                  },
+                  "default_payout": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-8
+                  },
+                  "default_payout_rate": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-8
+                  },
+                  "event_category": {
+                    "type": ["null", "string"]
+                  },
+                  "event_type_id": {
+                    "type": ["null", "integer"]
+                  },
+                  "event_type_name": {
+                    "type": ["null", "string"]
+                  },
+                  "limits": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "limit_by": {
+                              "type": ["null", "string"]
+                            },
+                            "period": {
+                              "type": ["null", "string"]
+                            },
+                            "type": {
+                              "type": ["null", "string"]
+                            },
+                            "subtype": {
+                              "type": ["null", "string"]
+                            },
+                            "value": {
+                              "type": ["null", "number"],
+                              "multipleOf": 1e-8
+                            },
+                            "weekend_override_value": {
+                              "type": ["null", "integer"]
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "location_requirement_countries": {
+                    "type": ["null", "string"]
+                  },
+                  "location_requirement_type": {
+                    "type": ["null", "string"]
+                  },
+                  "locking": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "basis": {
+                              "type": ["null", "string"]
+                            },
+                            "day_of_month": {
+                              "type": ["null", "integer"]
+                            },
+                            "day_offset": {
+                              "type": ["null", "integer"]
+                            },
+                            "max_months_open_ended_period": {
+                              "type": ["null", "integer"]
+                            },
+                            "month_offset": {
+                              "type": ["null", "integer"]
+                            },
+                            "open_ended_autolocking_mode": {
+                              "type": ["null", "string"]
+                            },
+                            "period": {
+                              "type": ["null", "string"]
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "payouts_adjustments": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "amount": {
+                              "type": ["null", "number"],
+                              "multipleOf": 1e-8
+                            },
+                            "direction": {
+                              "type": ["null", "string"]
+                            },
+                            "id": {
+                              "type": ["null", "string"]
+                            },
+                            "rate": {
+                              "type": ["null", "integer"]
+                            },
+                            "rules": {
+                              "anyOf": [
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "operator": {
+                                        "type": ["null", "string"]
+                                      },
+                                      "variable": {
+                                        "type": ["null", "string"]
+                                      },
+                                      "values": {
+                                        "anyOf": [
+                                          {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object"
+                                            }
+                                          },
+                                          {
+                                            "type": ["null", "string"]
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "payouts_groups": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "id": {
+                              "type": ["null", "string"]
+                            },
+                            "limits": {
+                              "anyOf": [
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "limit_by": {
+                                        "type": ["null", "string"]
+                                      },
+                                      "period": {
+                                        "type": ["null", "string"]
+                                      },
+                                      "type": {
+                                        "type": ["null", "string"]
+                                      },
+                                      "subtype": {
+                                        "type": ["null", "string"]
+                                      },
+                                      "value": {
+                                        "type": ["null", "number"],
+                                        "multipleOf": 1e-8
+                                      },
+                                      "weekend_override_value": {
+                                        "type": ["null", "integer"]
+                                      }
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "payout": {
+                              "type": ["null", "number"],
+                              "multipleOf": 1e-8
+                            },
+                            "payout_rate": {
+                              "type": ["null", "integer"]
+                            },
+                            "rank": {
+                              "type": ["null", "integer"]
+                            },
+                            "rules": {
+                              "anyOf": [
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "operator": {
+                                        "type": ["null", "string"]
+                                      },
+                                      "variable": {
+                                        "type": ["null", "string"]
+                                      },
+                                      "values": {
+                                        "anyOf": [
+                                          {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object"
+                                            }
+                                          },
+                                          {
+                                            "type": ["null", "string"]
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "tiers": {
+                              "anyOf": [
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "action_threshold": {
+                                        "type": ["null", "integer"]
+                                      },
+                                      "parent_tier": {
+                                        "type": ["null", "integer"]
+                                      },
+                                      "payout": {
+                                        "type": ["null", "number"],
+                                        "multipleOf": 1e-8
+                                      },
+                                      "payout_rate": {
+                                        "type": ["null", "number"],
+                                        "multipleOf": 1e-8
+                                      },
+                                      "revenue_threshold": {
+                                        "type": ["null", "number"],
+                                        "multipleOf": 1e-8
+                                      }
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "payout_level": {
+                    "type": ["null", "string"]
+                  },
+                  "payout_restrictions": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "id": {
+                              "type": ["null", "string"]
+                            },
+                            "rules": {
+                              "anyOf": [
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "operator": {
+                                        "type": ["null", "string"]
+                                      },
+                                      "variable": {
+                                        "type": ["null", "string"]
+                                      },
+                                      "values": {
+                                        "anyOf": [
+                                          {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object"
+                                            }
+                                          },
+                                          {
+                                            "type": ["null", "string"]
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "payout_scheduling": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "basis": {
+                              "type": ["null", "string"]
+                            },
+                            "day_offset": {
+                              "type": ["null", "integer"]
+                            },
+                            "month_offset": {
+                              "type": ["null", "integer"]
+                            },
+                            "period": {
+                              "type": ["null", "string"]
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "performance_bonus": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "basis": {
+                              "type": ["null", "string"]
+                            },
+                            "bonus_tiers": {
+                              "anyOf": [
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "action_threshold": {
+                                        "type": ["null", "integer"]
+                                      },
+                                      "payout": {
+                                        "type": ["null", "number"],
+                                        "multipleOf": 1e-8
+                                      },
+                                      "payout_rate": {
+                                        "type": ["null", "number"],
+                                        "multipleOf": 1e-8
+                                      },
+                                      "revenue_threshold": {
+                                        "type": ["null", "number"],
+                                        "multipleOf": 1e-8
+                                      }
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "period": {
+                              "type": ["null", "string"]
+                            },
+                            "type": {
+                              "type": ["null", "string"]
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "valid_referrals": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "type": {
+                              "type": ["null", "string"]
+                            },
+                            "window": {
+                              "type": ["null", "integer"]
+                            },
+                            "window_unit": {
+                              "type": ["null", "string"]
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "first_action_slotting_fee": {
+          "type": ["null", "number"],
+          "multipleOf": 1e-8
+        },
+        "labels": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": ["null", "string"]
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max_return_percentage": {
+          "type": ["null", "number"],
+          "multipleOf": 1e-8
+        },
+        "min_earning_per_click": {
+          "type": ["null", "number"],
+          "multipleOf": 1e-8
+        },
+        "monthly_slotting_fee": {
+          "type": ["null", "number"],
+          "multipleOf": 1e-8
+        },
+        "name": {
+          "type": ["null", "string"]
+        },
+        "return_policy": {
+          "type": ["null", "string"]
+        },
+        "special_terms_list": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "terms_content": {
+                    "type": ["null", "string"]
+                  },
+                  "terms_name": {
+                    "type": ["null", "string"]
+                  },
+                  "terms_pdf_uri": {
+                    "type": ["null", "string"]
+                  },
+                  "terms_type": {
+                    "type": ["null", "string"]
+                  }
+                }
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "spend_limit": {
+          "type": ["null", "number"],
+          "multipleOf": 1e-8
+        },
+        "spend_limit_period": {
+          "type": ["null", "string"]
+        },
+        "template_id": {
+          "type": ["null", "integer"]
+        },
+        "version_id": {
+          "type": ["null", "integer"]
+        }
+      }
+    },
+    "uri": {
+      "type": ["null", "string"]
+    }
+  }
+}

--- a/tap_impact/streams.py
+++ b/tap_impact/streams.py
@@ -85,6 +85,13 @@ STREAMS = {
                 'replication_method': 'FULL_TABLE',
                 'parent': 'campaign'
             },
+            'contracts': {
+                'path': 'Campaigns/{}/Contracts',
+                'data_key': 'Contracts',
+                'key_properties': ['id'],
+                'replication_method': 'FULL_TABLE',
+                'parent': 'campaign'
+            },
             'conversion_paths': {
                 'path': 'Campaigns/{}/Models/<model_id>/ConversionPaths',
                 'data_key': 'ConversionPaths',


### PR DESCRIPTION
# Description of change

I'm continuing to update the tap to work with the Impact Radius API v10 (latest stable version). This includes:

- Some minor updates to existing schemas (action_updates, contacts, company_information, campaigns) to match [the API documentation](https://integrations.impact.com/impact-brand/reference/how-to-structure-requests).
- Adding a new schema for [the Contracts endpoint](https://integrations.impact.com/impact-brand/reference/contracts-overview). This resources wasn't available previously.

# Manual QA steps

Probably most relevant to QA is the new `Contracts` data. The rest is all minor modifications.

- Make sure the `config.json` file is updated with the credentials needed.
- Run `tap-impact --config config.json --discover > catalog.json` to generate the catalog with the new schema.
- In the `catalog.json` file, find the metadata associated with the campaigns stream (parent stream) & contracts stream.
- Add the line "selected": true like in the example below. This will ensure that you actually pull in this data locally when you run the next command.

```
"stream": "campaigns",
      "metadata": [
        {
          "breadcrumb": [],
          "metadata": {
            "table-key-properties": [
              "id"
            ],
            "forced-replication-method": "FULL_TABLE",
            "inclusion": "available",
            "selected": true
          }
        },
```
- Run `tap-impact --config config.json --catalog catalog.json > state.json`. This will pull the selected data and dump it in the `state.json` file.
- Once the job has completed, you can check `state.json` to validate your data.
 
# Risks

This assumes you're working with v10 of the Impact Radius API.
