### PR TITLE
Add extraction date to all streams, schemas need to be updated

### DIFF
--- a/tap_impact/schemas/action_inquiries.json
+++ b/tap_impact/schemas/action_inquiries.json
@@ -98,6 +98,10 @@
     },
     "uri": {
       "type": ["null", "string"]
+    },
+    "extraction_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_impact/schemas/action_updates.json
+++ b/tap_impact/schemas/action_updates.json
@@ -125,6 +125,10 @@
     },
     "uri": {
       "type": ["null", "string"]
+    },
+    "extraction_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_impact/schemas/actions.json
+++ b/tap_impact/schemas/actions.json
@@ -127,6 +127,10 @@
     },
     "uri": {
       "type": ["null", "string"]
+    },
+    "extraction_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_impact/schemas/ads.json
+++ b/tap_impact/schemas/ads.json
@@ -305,6 +305,10 @@
     },
     "uri": {
       "type": ["null", "string"]
-    }    
+    },
+    "extraction_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    }
   }
 }

--- a/tap_impact/schemas/api_submissions.json
+++ b/tap_impact/schemas/api_submissions.json
@@ -48,6 +48,10 @@
     },
     "uri": {
       "type": ["null", "string"]
+    },
+    "extraction_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_impact/schemas/campaigns.json
+++ b/tap_impact/schemas/campaigns.json
@@ -232,7 +232,7 @@
     "view_through_crediting": {
       "type": ["null", "boolean"]
     },
-    "extraction_time": {
+    "extraction_date": {
       "type": ["null", "string"],
       "format": "date-time"
     }

--- a/tap_impact/schemas/campaigns.json
+++ b/tap_impact/schemas/campaigns.json
@@ -231,6 +231,10 @@
     },
     "view_through_crediting": {
       "type": ["null", "boolean"]
+    },
+    "extraction_time": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_impact/schemas/catalog_items.json
+++ b/tap_impact/schemas/catalog_items.json
@@ -244,6 +244,10 @@
     },
     "weight_unit": {
       "type": ["null", "string"]
+    },
+    "extraction_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_impact/schemas/catalogs.json
+++ b/tap_impact/schemas/catalogs.json
@@ -35,6 +35,10 @@
     },
     "uri": {
       "type": ["null", "string"]
+    },
+    "extraction_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_impact/schemas/clicks.json
+++ b/tap_impact/schemas/clicks.json
@@ -121,6 +121,10 @@
     },
     "unique_click": {
       "type": ["null", "boolean"]
+    },
+    "extraction_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_impact/schemas/company_information.json
+++ b/tap_impact/schemas/company_information.json
@@ -184,6 +184,10 @@
     },
     "website": {
       "type": ["null", "string"]
+    },
+    "extraction_time": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_impact/schemas/company_information.json
+++ b/tap_impact/schemas/company_information.json
@@ -185,7 +185,7 @@
     "website": {
       "type": ["null", "string"]
     },
-    "extraction_time": {
+    "extraction_date": {
       "type": ["null", "string"],
       "format": "date-time"
     }

--- a/tap_impact/schemas/contacts.json
+++ b/tap_impact/schemas/contacts.json
@@ -75,6 +75,10 @@
     },
     "work_phone_number_country": {
       "type": ["null", "string"]
+    },
+    "extraction_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_impact/schemas/contracts.json
+++ b/tap_impact/schemas/contracts.json
@@ -627,6 +627,10 @@
     },
     "uri": {
       "type": ["null", "string"]
+    },
+    "extraction_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_impact/schemas/conversion_paths.json
+++ b/tap_impact/schemas/conversion_paths.json
@@ -324,6 +324,10 @@
           "type": "null"
         }
       ]
+    },
+    "extraction_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_impact/schemas/deals.json
+++ b/tap_impact/schemas/deals.json
@@ -190,6 +190,10 @@
     },
     "uri": {
       "type": ["null", "string"]
+    },
+    "extraction_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_impact/schemas/exception_list_items.json
+++ b/tap_impact/schemas/exception_list_items.json
@@ -23,6 +23,10 @@
     },
     "value": {
       "type": ["null", "string"]
+    },
+    "extraction_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_impact/schemas/exception_lists.json
+++ b/tap_impact/schemas/exception_lists.json
@@ -55,6 +55,10 @@
     },
     "uri": {
       "type": ["null", "string"]
+    },
+    "extraction_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_impact/schemas/ftp_file_submissions.json
+++ b/tap_impact/schemas/ftp_file_submissions.json
@@ -36,6 +36,10 @@
     },
     "uri": {
       "type": ["null", "string"]
+    },
+    "extraction_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_impact/schemas/invoices.json
+++ b/tap_impact/schemas/invoices.json
@@ -82,6 +82,10 @@
     "total_vat_amount": {
       "type": ["null", "number"],
       "multipleOf": 1e-8
+    },
+    "extraction_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_impact/schemas/media_partner_groups.json
+++ b/tap_impact/schemas/media_partner_groups.json
@@ -38,6 +38,10 @@
     },
     "uri": {
       "type": ["null", "string"]
+    },
+    "extraction_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_impact/schemas/media_partners.json
+++ b/tap_impact/schemas/media_partners.json
@@ -331,6 +331,10 @@
     },
     "website": {
       "type": ["null", "string"]
+    },
+    "extraction_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_impact/schemas/notes.json
+++ b/tap_impact/schemas/notes.json
@@ -45,6 +45,10 @@
     },
     "uri": {
       "type": ["null", "string"]
+    },
+    "extraction_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_impact/schemas/phone_numbers.json
+++ b/tap_impact/schemas/phone_numbers.json
@@ -28,6 +28,10 @@
     },
     "uri": {
       "type": ["null", "string"]
+    },
+    "extraction_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_impact/schemas/promo_codes.json
+++ b/tap_impact/schemas/promo_codes.json
@@ -226,6 +226,10 @@
     },
     "uri": {
       "type": ["null", "string"]
+    },
+    "extraction_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_impact/schemas/report_metadata.json
+++ b/tap_impact/schemas/report_metadata.json
@@ -66,6 +66,10 @@
     },
     "uri": {
       "type": ["null", "string"]
+    },
+    "extraction_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_impact/schemas/reports.json
+++ b/tap_impact/schemas/reports.json
@@ -16,6 +16,10 @@
     },
     "run_uri": {
       "type": ["null", "string"]
+    },
+    "extraction_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_impact/schemas/tracking_value_requests.json
+++ b/tap_impact/schemas/tracking_value_requests.json
@@ -310,6 +310,10 @@
     },
     "uri": {
       "type": ["null", "string"]
+    },
+    "extraction_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_impact/schemas/unique_urls.json
+++ b/tap_impact/schemas/unique_urls.json
@@ -40,6 +40,10 @@
     },
     "url": {
       "type": ["null", "string"]
+    },
+    "extraction_date": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_impact/transform.py
+++ b/tap_impact/transform.py
@@ -5,8 +5,6 @@ from datetime import datetime
 LOGGER = singer.get_logger()
 
 # Convert camelCase to snake_case
-
-
 def convert(name):
     regsub = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
     return re.sub('([a-z0-9])([A-Z])', r'\1_\2', regsub).lower()
@@ -41,7 +39,7 @@ def convert_json(this_json):
 # Add a field to each record to keep track of the extraction date
 def add_extraction_date(records):
     for record in records:
-        record["extraction_date"] = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+        record["extraction_time"] = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
     return records
 
 
@@ -88,8 +86,7 @@ def transform_conversion_paths(this_json, data_key):
         this_json[data_key][i]['referral_counts'] = []
         for referral_count in referral_counts_list:
             if isinstance(referral_count, dict):
-                this_json[data_key][i]['referral_counts'].append(
-                    referral_count)
+                this_json[data_key][i]['referral_counts'].append(referral_count)
 
         i = i + 1
     return this_json
@@ -100,13 +97,11 @@ def transform_json(this_json, stream_name, data_key):
     converted_json = convert_json(this_json)
     converted_data_key = convert(data_key)
     if stream_name in ('actions', 'action_updates'):
-        transformed_json = replace_order_id(converted_json, converted_data_key)[
-            converted_data_key]
+        transformed_json = replace_order_id(converted_json, converted_data_key)[converted_data_key]
     if stream_name in ['conversion_paths']:
-        transformed_json = transform_conversion_paths(
-            converted_json, converted_data_key)[converted_data_key]
+        transformed_json = transform_conversion_paths(converted_json, converted_data_key)[converted_data_key]
     else:
         transformed_json = converted_json[converted_data_key]
-
+    
     records_with_timestamp = add_extraction_date(transformed_json)
     return records_with_timestamp

--- a/tap_impact/transform.py
+++ b/tap_impact/transform.py
@@ -1,5 +1,6 @@
 import re
 import singer
+from datetime import datetime
 
 LOGGER = singer.get_logger()
 
@@ -34,6 +35,12 @@ def convert_json(this_json):
         else:
             out[new_key] = this_json[key]
     return out
+
+# Add a field to each record to keep track of the extraction date
+def add_extraction_date(records):
+    for record in records:
+        record["extraction_time"] = datetime.utcnow().isoformat()
+    return records
 
 
 # Replace system/reserved field 'oid' with 'order_id'
@@ -95,4 +102,6 @@ def transform_json(this_json, stream_name, data_key):
         transformed_json = transform_conversion_paths(converted_json, converted_data_key)[converted_data_key]
     else:
         transformed_json = converted_json[converted_data_key]
-    return transformed_json
+    
+    records_with_timestamp = add_extraction_date(transformed_json)
+    return records_with_timestamp

--- a/tap_impact/transform.py
+++ b/tap_impact/transform.py
@@ -5,6 +5,8 @@ from datetime import datetime
 LOGGER = singer.get_logger()
 
 # Convert camelCase to snake_case
+
+
 def convert(name):
     regsub = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
     return re.sub('([a-z0-9])([A-Z])', r'\1_\2', regsub).lower()
@@ -39,7 +41,7 @@ def convert_json(this_json):
 # Add a field to each record to keep track of the extraction date
 def add_extraction_date(records):
     for record in records:
-        record["extraction_time"] = datetime.utcnow().isoformat()
+        record["extraction_date"] = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
     return records
 
 
@@ -86,7 +88,8 @@ def transform_conversion_paths(this_json, data_key):
         this_json[data_key][i]['referral_counts'] = []
         for referral_count in referral_counts_list:
             if isinstance(referral_count, dict):
-                this_json[data_key][i]['referral_counts'].append(referral_count)
+                this_json[data_key][i]['referral_counts'].append(
+                    referral_count)
 
         i = i + 1
     return this_json
@@ -97,11 +100,13 @@ def transform_json(this_json, stream_name, data_key):
     converted_json = convert_json(this_json)
     converted_data_key = convert(data_key)
     if stream_name in ('actions', 'action_updates'):
-        transformed_json = replace_order_id(converted_json, converted_data_key)[converted_data_key]
+        transformed_json = replace_order_id(converted_json, converted_data_key)[
+            converted_data_key]
     if stream_name in ['conversion_paths']:
-        transformed_json = transform_conversion_paths(converted_json, converted_data_key)[converted_data_key]
+        transformed_json = transform_conversion_paths(
+            converted_json, converted_data_key)[converted_data_key]
     else:
         transformed_json = converted_json[converted_data_key]
-    
+
     records_with_timestamp = add_extraction_date(transformed_json)
     return records_with_timestamp


### PR DESCRIPTION
# Description of change

Add `extraction_date` field to all schemas. This is a necessary field in order to keep historical data while avoiding duplication.

# Manual QA steps

- Make sure the `config.json` file is updated with the credentials needed.
- Run `tap-impact --config config.json --discover > catalog.json` to generate the catalog with the new schema.
- In the `catalog.json` file, find the metadata associated with the campaigns stream (parent stream) & contracts stream.
- Add the line `"selected": true` like in the example below. This will ensure that you actually pull in this data locally when you run the next command.

```
"stream": "campaigns",
      "metadata": [
        {
          "breadcrumb": [],
          "metadata": {
            "table-key-properties": [
              "id"
            ],
            "forced-replication-method": "FULL_TABLE",
            "inclusion": "available",
            "selected": true
          }
        },
```
- Run `tap-impact --config config.json --catalog catalog.json > state.json`. This will pull the selected data and dump it in the `state.json` file.
- Once the job has completed, you can check `state.json` to validate your data.
 
# Risks

This is a schema change. It may create compatibility issues with existing datasets. For our use case, we will simply reimport the data to ensure all our historical data has the `extraction_date` field.
