### PR TITLE
Fix record filtering

### DIFF
--- a/tap_impact/streams.py
+++ b/tap_impact/streams.py
@@ -66,7 +66,7 @@ STREAMS = {
                 },
                 'key_properties': ['id'],
                 'replication_method': 'INCREMENTAL',
-                'replication_keys': ['locking_date'],
+                'replication_keys': ['update_date'],
                 'bookmark_type': 'datetime'
             },
             'clicks': {


### PR DESCRIPTION
# Description of change

This changes the incremental key for the `actions` table to make sure we capture state transitions (e.g. PENDING -> APPROVED). Using `event_date` prevents us from capturing these transitions.

## Explanation

- The `actions` table is pulled in as an _incremental_ table.
- That works via defining a "replication key" for a given table. For `actions` the replication key currently used is `event_date` (defined [here](https://github.com/Shopify/tap-impact/blob/0515b6b2adccab9a5bf7a58c4b8f6052d92623a4/tap_impact/streams.py#L45)).
- Each time the job is run, we keep track of the replication key & store it in state (called a bookmark).
- From the perspective of the tap, all records up to that date have been processed and shouldn't be processed again. Records with a replication key earlier than the "bookmarked" one will be discarded (see filtering logic [here](https://github.com/Shopify/tap-impact/blob/0515b6b2adccab9a5bf7a58c4b8f6052d92623a4/tap_impact/sync.py#L98C17-L113C52)).

The problem: since the tap is filtering on `event_date`, it won't pull updates. Using an example action ID from our data, we should see this transition, but we see only the PENDING state:

```
event_date: 2023-06-20 02:45:53 UTC
locking_date: 2023-07-16 04:00:00 UTC
cleared_date: null
state: PENDING
```

Pulling that same action via an API call shows:

```
event_date: 2023-06-19T22:45:53-04:00 <-- this is the important bit!
locking_date: 2023-07-16T00:00:00-04:00
cleared_date: 2023-07-16T01:15:10-04:00
state: APPROVED
```

There's a small variation of the event date (probably due to UTC conversion), but the important part is that the record update won't be processed if we keep track of incrementality via the `event_date` field.

# Manual QA steps

Running the job locally will succeed (non-breaking change), but doesn't tell us what we want.

To properly test, the job needs to run multiple times while keeping track of state. Use what is available for your team.
 
# Risks

The risk is minimal since the current functionality is buggy.
