### PR TITLE
Potench/fix actions api

### DIFF
--- a/tap_impact/streams.py
+++ b/tap_impact/streams.py
@@ -39,7 +39,7 @@ STREAMS = {
                 'params': {
                     'CampaignId': '<parent_id>',
                     'ActionDateStart': '<last_datetime>',
-                    'ActionDateEnd': '<time_extracted>',
+                    'ActionDateEnd': '<current_datetime>',
                 },
                 'key_properties': ['id'],
                 'replication_method': 'INCREMENTAL',
@@ -52,7 +52,7 @@ STREAMS = {
                 'params': {
                     'CampaignId': '<parent_id>',
                     'StartDate': '<last_datetime>',
-                    'EndDate': '<time_extracted>'
+                    'EndDate': '<current_datetime>'
                 },
                 'key_properties': ['id'],
                 'replication_method': 'INCREMENTAL',
@@ -65,7 +65,7 @@ STREAMS = {
                 'params': {
                     'CampaignId': '<parent_id>',
                     'StartDate': '<last_datetime>',
-                    'EndDate': '<time_extracted>'
+                    'EndDate': '<current_datetime>'
                 },
                 'key_properties': ['id'],
                 'replication_method': 'INCREMENTAL',

--- a/tap_impact/streams.py
+++ b/tap_impact/streams.py
@@ -38,7 +38,8 @@ STREAMS = {
                 'data_key': 'Actions',
                 'params': {
                     'CampaignId': '<parent_id>',
-                    'ActionDateStart': '<last_datetime>'
+                    'ActionDateStart': '<last_datetime>',
+                    'ActionDateEnd': '<time_extracted>',
                 },
                 'key_properties': ['id'],
                 'replication_method': 'INCREMENTAL',
@@ -50,7 +51,8 @@ STREAMS = {
                 'data_key': 'ActionInquiries',
                 'params': {
                     'CampaignId': '<parent_id>',
-                    'StartDate': '<last_datetime>'
+                    'StartDate': '<last_datetime>',
+                    'EndDate': '<time_extracted>'
                 },
                 'key_properties': ['id'],
                 'replication_method': 'INCREMENTAL',
@@ -62,7 +64,8 @@ STREAMS = {
                 'data_key': 'ActionUpdates',
                 'params': {
                     'CampaignId': '<parent_id>',
-                    'StartDate': '<last_datetime>'
+                    'StartDate': '<last_datetime>',
+                    'EndDate': '<time_extracted>'
                 },
                 'key_properties': ['id'],
                 'replication_method': 'INCREMENTAL',

--- a/tap_impact/sync.py
+++ b/tap_impact/sync.py
@@ -152,6 +152,8 @@ def sync_endpoint(client,
 
     end_dttm = utils.now()
     end_dt = end_dttm.date()
+    end_dt_str = end_dt.strftime('%Y-%m-%dT%H:%M:%SZ')
+
     start_dttm = end_dttm
     start_dt = end_dt
 
@@ -166,7 +168,7 @@ def sync_endpoint(client,
     date_list = [str(start_dt + timedelta(days=x)) for x in range((end_dt - start_dt).days + 1)]
     endpoint_total = 0
     total_records = 0
-    limit = 1000 # PageSize (default for API is 100)
+    limit = 20000 # PageSize (default for API is 20000)
     for bookmark_date in date_list:
         page = 1
         offset = 0
@@ -190,8 +192,13 @@ def sync_endpoint(client,
 
             if page == 1 and not params == {}:
                 param_string = '&'.join(['%s=%s' % (key, value) for (key, value) in params.items()])
-                querystring = param_string.replace('<parent_id>', str(parent_id)).replace(
-                    '<last_datetime>', strptime_to_utc(last_datetime).strftime('%Y-%m-%dT%H:%M:%SZ'))
+                querystring = (
+                    param_string
+                    .replace('<parent_id>', str(parent_id))
+                    .replace('<last_datetime>', strptime_to_utc(last_datetime).strftime('%Y-%m-%dT%H:%M:%SZ'))
+                    .replace('<time_extracted>', strptime_to_utc(end_dt_str).strftime('%Y-%m-%dT%H:%M:%SZ'))
+                )
+                # querystring = param_string.replace('<parent_id>', str(parent_id)).replace('<last_datetime>', strptime_to_utc(last_datetime).strftime('%Y-%m-%dT%H:%M:%SZ')).replace('<current_datetime>', strptime_to_utc(end_date).strftime('%Y-%m-%dT%H:%M:%SZ'))
             else:
                 querystring = None
             LOGGER.info('URL for Stream {}: {}{}'.format(

--- a/tap_impact/sync.py
+++ b/tap_impact/sync.py
@@ -196,7 +196,7 @@ def sync_endpoint(client,
                     param_string
                     .replace('<parent_id>', str(parent_id))
                     .replace('<last_datetime>', strptime_to_utc(last_datetime).strftime('%Y-%m-%dT%H:%M:%SZ'))
-                    .replace('<time_extracted>', strptime_to_utc(end_dt_str).strftime('%Y-%m-%dT%H:%M:%SZ'))
+                    .replace('<current_datetime>', strptime_to_utc(end_dt_str).strftime('%Y-%m-%dT%H:%M:%SZ'))
                 )
                 # querystring = param_string.replace('<parent_id>', str(parent_id)).replace('<last_datetime>', strptime_to_utc(last_datetime).strftime('%Y-%m-%dT%H:%M:%SZ')).replace('<current_datetime>', strptime_to_utc(end_date).strftime('%Y-%m-%dT%H:%M:%SZ'))
             else:


### PR DESCRIPTION
Fixes https://github.com/Shopify/shopify-cdp/issues/2195 

# Description of change

According [to api docs](https://integrations.impact.com/impact-brand/reference/list-all-actions), `EndDate` is required when providing a `StartDate`.  Including an `EndDate` should resolve [the errors](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_job%22%20resource.labels.job_name%20%3D%20%22meltano-impact-radius-extractor%22%20labels.%22run.googleapis.com%2Fexecution_name%22%20%3D%20%22meltano-impact-radius-extractor-zsjcg%22%20resource.labels.location%20%3D%20%22us-central1%22%20timestamp%20%3C%3D%20%222024-08-12T19:07:39.023Z%22%20severity%3E%3DDEFAULT;storageScope=project;cursorTimestamp=2024-08-12T18:07:23.670504Z;duration=P1D?project=shopify-paid-marketing)

```json
ERROR ERROR 400: {\"Status\":\"ERROR\",\"Message\":\"Parameter 'ActionDateEnd' value is required.\"}
```

<img width="400" alt="Screenshot 2024-08-12 at 1 23 51 PM" src="https://github.com/user-attachments/assets/1e63c8d2-0072-4aac-90c1-28e061683505">

------------

- [x] Update the action* api end-points to include an `EndDate` as a required param (`ActionDateEnd` + `EndDate` provided by the `time_extracted` value (which is `now()`)
    > If no StartDate and EndDate parameters are specified, only records for the past 7 days will be returned.
- [ ] Increase default page size to the most current API default page size. 
    > The new default page size is 20,000 records per page when PageSize isn’t specified.

# Manual QA steps

```
dev clone growth-paid-data-extractors 
dev up

# Change `subconfigs/extractors/tap-impact.meltano.yml` pip_url and start_date attribute to
pip_url: git+https://github.com/Shopify/tap-impact.git@potench/fix-actions-api
start_date: '2024-08-10T00:00:00Z'

# install updated tap 
meltano install extractor tap-impact 

# execute 
meltano run tap-impact target-jsonl 

# expect no errors
```
 
# Risks
 - Backed up since Aug 6th, so we may have more than 20k records - the job may fail if `end_time` + pagination doesn't boundary produces > 20k records.
 
# Rollback steps
 - revert this branch
