### PR TITLE
revert back to FULL_TABLE for media_partners stream

### DIFF
--- a/tap_impact/streams.py
+++ b/tap_impact/streams.py
@@ -182,15 +182,9 @@ STREAMS = {
     },
     'media_partners': {
         'path': 'MediaPartners',
-        'params': {
-            'StartDate': '<last_datetime>',
-            'EndDate': '<current_datetime>'
-        },
         'data_key': 'Partners',
         'key_properties': ['id'],
-        'replication_method': 'INCREMENTAL',
-        'replication_keys': ['date_last_updated'],
-        'bookmark_type': 'datetime'
+        'replication_method': 'FULL_TABLE',
     },
     'phone_numbers': {
         'path': 'PhoneNumbers',


### PR DESCRIPTION
# Description of change
It's been [reported](https://shopify.slack.com/archives/C01FBHZ0KDW/p1756156126291969) that the `date_last_updated` field doesn't actually get updated every day. This means since it's an incremental load, the team isn't getting the most recent data every day. In addition, the change to INCREMENTAL in the last PR has not prevented the tap from failing. This means INCREMENTAL does not help the tap from timing out anyway so we are reverting back to FULL_TABLE as a result so at least the team can get up to date data.

<img width="1144" height="818" alt="Screenshot 2025-09-03 at 3 23 50 PM" src="https://github.com/user-attachments/assets/a1425c13-fcbb-47b1-b90c-3b514f480de4" />

# Manual QA steps
 - locally tested the changes, the data was uploaded to this [table](https://console.cloud.google.com/bigquery?ws=!1m5!1m4!4m3!1sshopify-stg-dw!2snanamathis_raw_meta_ads!3smedia_partners) 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
