### PR TITLE
Lowering page size from 20k to 500

### DIFF
--- a/tap_impact/sync.py
+++ b/tap_impact/sync.py
@@ -169,7 +169,7 @@ def sync_endpoint(client,
     date_list = [str(start_dt + timedelta(days=x)) for x in range((end_dt - start_dt).days + 1)]
     endpoint_total = 0
     total_records = 0
-    limit = 20000 # PageSize (default for API is 20000)
+    limit = 500 # PageSize (default for API is 1000, but we're limiting to 500 to avoid load errors on the API which were quite common)
     for bookmark_date in date_list:
         page = 1
         offset = 0
@@ -213,7 +213,7 @@ def sync_endpoint(client,
                 path=path,
                 params=querystring,
                 endpoint=stream_name)
-
+            
             # time_extracted: datetime when the data was extracted from the API
             time_extracted = utils.now()
             if not data or data is None or data == {}:

--- a/tap_impact/sync.py
+++ b/tap_impact/sync.py
@@ -213,7 +213,6 @@ def sync_endpoint(client,
                 path=path,
                 params=querystring,
                 endpoint=stream_name)
-            
             # time_extracted: datetime when the data was extracted from the API
             time_extracted = utils.now()
             if not data or data is None or data == {}:

--- a/tap_impact/sync.py
+++ b/tap_impact/sync.py
@@ -213,6 +213,7 @@ def sync_endpoint(client,
                 path=path,
                 params=querystring,
                 endpoint=stream_name)
+
             # time_extracted: datetime when the data was extracted from the API
             time_extracted = utils.now()
             if not data or data is None or data == {}:


### PR DESCRIPTION
# Description of change
Our impact radius extractor fails almost every day on unknown errors that seem to imply an issue on Impact Radius' side on returning large amounts of data. I am lowering the page size to 500 here, which appears to work locally in minimizing these issues. 

None of the[ Impact streams](https://1d63b7b005274318bfa6dd2a60561abc-dot-us-central1.composer.googleusercontent.com/dags/dw.impact_metrics_extractor.production/grid?search=dw.impact_metrics_extractor.production&dag_run_id=scheduled__2025-09-24T23%3A59%3A00%2B00%3A00&tab=logs&task_id=meltano__impact_rest_of_streams__to__bigquery_impact) appear to pick up more than a couple hundred rows of data every day, so this should be safe and help with load from the API. 

# Manual QA steps
 - Running `meltano run tap-impact-invoices target-jsonl` led to a successful run. 
 
# Risks
 - Increased number of load jobs, but it should always be less than 10 or so considering the size of the data. 
 
# Rollback steps
 - revert this branch
