### PR TITLE
Update media partners stream

### DIFF
--- a/tap_impact/streams.py
+++ b/tap_impact/streams.py
@@ -203,7 +203,7 @@ STREAMS = {
         'path': 'MediaPartners',
         'data_key': 'Partners',
         'key_properties': ['id'],
-        'page_size': 20000,
+        'page_size': 1000,
         'replication_method': 'FULL_TABLE',
     },
     'phone_numbers': {


### PR DESCRIPTION
# Description of change
(write a short description or paste a link to JIRA)
We noticed media partners stream is timing out due to the large page size. We've reported this to the Impact team and are waiting on a fix but for now would like to change the page size to 1000 which has worked locally.

# Manual QA steps
 Tested the tap locally and it completed succcessfully.
 
<img width="1138" height="431" alt="Screenshot 2025-10-21 at 12 27 56 PM" src="https://github.com/user-attachments/assets/4f5f00f1-275f-41d4-806d-2390fa45b991" />

# Risks
 There aren't really any risks because it's already failing and not working in production.
 
# Rollback steps
 - revert this branch
