### PR TITLE
Update notes stream

### DIFF
--- a/tap_impact/streams.py
+++ b/tap_impact/streams.py
@@ -125,9 +125,7 @@ STREAMS = {
                 'data_key': 'Notes',
                 'key_properties': ['id'],
                 'page_size': 20000,
-                'replication_method': 'INCREMENTAL',
-                'replication_keys': ['modification_date'],
-                'bookmark_type': 'datetime',
+                'replication_method': 'FULL_TABLE',
                 'parent': 'campaign'
             }
         }


### PR DESCRIPTION
# Description of change
I was trying to add notes as a stream to the impact tap but was getting nothing from the results. I believe this was due to the stream setting it's replication_method to INCREMENTAL instead of FULL_TABLE. The notes endpoint doesn't contain any date filtering and so it doesn't really make sense to have it be incremental. The notes data is also very small so it doesn't require a lot to fully regenerate the table.


# Manual QA steps

 I tested this locally and was able to fetch the data.
<img width="1026" height="263" alt="Screenshot 2026-02-25 at 10 36 44 AM" src="https://github.com/user-attachments/assets/f6bde947-a676-421d-9d7c-99997b884512" />

# Risks

# Rollback steps
 - revert this branch
