### PR TITLE
fix: Fixes contracts events_payouts data being silently dropped by Singer transformer.

### DIFF
--- a/tap_impact/transform.py
+++ b/tap_impact/transform.py
@@ -92,73 +92,122 @@ def transform_conversion_paths(this_json, data_key):
     return this_json
 
 
-# Unwrap XML-style container objects into flat arrays.
-# The Impact API returns nested arrays wrapped in container objects, e.g.:
-#   "EventPayouts": {"EventPayout": [{...}, ...]}  (multiple items)
-#   "EventPayouts": {"EventPayout": {...}}          (single item as dict)
-# After camelCase conversion this becomes:
-#   "events_payouts": {"event_payout": [{...}, ...]}
-# But the schema expects events_payouts to be a flat array.
-def unwrap_container(value, singular_key):
-    """Unwrap a container object into a list.
+# Safely coerce a string value to int, returning None on failure.
+def _safe_int(value):
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return None
 
-    Args:
-        value: The field value (could be list, dict-wrapper, or None).
-        singular_key: The snake_case singular key inside the wrapper dict.
 
-    Returns:
-        A list of items.
-    """
+# Safely coerce a string value to float, returning None on failure.
+def _safe_float(value):
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return float(value)
+    except (ValueError, TypeError):
+        return None
+
+
+# Ensure a value is a list.  Handles:
+#   None          -> []
+#   [items]       -> [items]          (already a list)
+#   {single_obj}  -> [{single_obj}]   (API returns single object instead of array)
+def _ensure_list(value):
     if value is None:
         return []
     if isinstance(value, list):
         return value
     if isinstance(value, dict):
-        inner = value.get(singular_key, [])
-        if isinstance(inner, list):
-            return inner
-        elif isinstance(inner, dict):
-            return [inner]
-        return []
+        return [value]
     return []
 
 
-# Unwrap nested arrays in contract template_terms that use XML-style wrappers.
-# Affected fields: events_payouts, labels, special_terms_list, and nested arrays
-# within events_payouts items (limits, locking, payouts_adjustments, payouts_groups,
-# payout_restrictions, payout_scheduling, performance_bonus, valid_referrals).
+# Transform contracts to fix type mismatches between the Impact API response
+# and the Singer schema.  The API returns many numeric values as strings and
+# single nested objects where the schema expects arrays.
+#
+# Without these coercions the Singer transformer silently drops the entire
+# events_payouts array because it fails strict schema validation.
 def transform_contracts(this_json, data_key):
     for record in this_json[data_key]:
         template_terms = record.get('template_terms')
         if not template_terms or not isinstance(template_terms, dict):
             continue
 
-        # Unwrap top-level arrays in template_terms
-        template_terms['events_payouts'] = unwrap_container(
-            template_terms.get('events_payouts'), 'event_payout')
-        template_terms['labels'] = unwrap_container(
-            template_terms.get('labels'), 'label')
-        template_terms['special_terms_list'] = unwrap_container(
-            template_terms.get('special_terms_list'), 'special_terms')
+        # --- top-level template_terms: coerce string -> int/float ---
+        template_terms['change_notification_period'] = _safe_int(
+            template_terms.get('change_notification_period'))
+        template_terms['max_return_percentage'] = _safe_float(
+            template_terms.get('max_return_percentage'))
+        template_terms['template_id'] = _safe_int(
+            template_terms.get('template_id'))
+        template_terms['version_id'] = _safe_int(
+            template_terms.get('version_id'))
+        template_terms['contract_start_slotting_fee'] = _safe_float(
+            template_terms.get('contract_start_slotting_fee'))
+        template_terms['first_action_slotting_fee'] = _safe_float(
+            template_terms.get('first_action_slotting_fee'))
+        template_terms['min_earning_per_click'] = _safe_float(
+            template_terms.get('min_earning_per_click'))
+        template_terms['monthly_slotting_fee'] = _safe_float(
+            template_terms.get('monthly_slotting_fee'))
+        template_terms['spend_limit'] = _safe_float(
+            template_terms.get('spend_limit'))
+        template_terms['action_limit'] = _safe_int(
+            template_terms.get('action_limit'))
 
-        # Unwrap nested arrays within each event_payout item
+        # --- ensure array fields are lists (API may return None or single dict) ---
+        template_terms['events_payouts'] = _ensure_list(
+            template_terms.get('events_payouts'))
+        template_terms['labels'] = _ensure_list(
+            template_terms.get('labels'))
+        template_terms['special_terms_list'] = _ensure_list(
+            template_terms.get('special_terms_list'))
+
+        # --- drop fields not in schema (additionalProperties: false) ---
+        template_terms.pop('promotional_terms', None)
+
+        # --- events_payouts items: coerce types + ensure nested arrays ---
         for ep in template_terms.get('events_payouts', []):
             if not isinstance(ep, dict):
                 continue
-            ep['limits'] = unwrap_container(ep.get('limits'), 'limit')
-            ep['locking'] = unwrap_container(ep.get('locking'), 'locking')
-            ep['payouts_adjustments'] = unwrap_container(
-                ep.get('payouts_adjustments'), 'payouts_adjustment')
-            ep['payouts_groups'] = unwrap_container(
-                ep.get('payouts_groups'), 'payouts_group')
-            ep['payout_restrictions'] = unwrap_container(
-                ep.get('payout_restrictions'), 'payout_restriction')
-            ep['payout_scheduling'] = unwrap_container(
-                ep.get('payout_scheduling'), 'payout_schedule')
-            ep['performance_bonus'] = unwrap_container(
-                ep.get('performance_bonus'), 'performance_bonus')
-            ep['valid_referrals'] = unwrap_container(
-                ep.get('valid_referrals'), 'valid_referral')
+
+            # string -> int / float coercions
+            ep['event_type_id'] = _safe_int(ep.get('event_type_id'))
+            ep['default_payout'] = _safe_float(ep.get('default_payout'))
+            ep['default_payout_rate'] = _safe_float(ep.get('default_payout_rate'))
+
+            # ensure sub-objects are always lists
+            ep['limits'] = _ensure_list(ep.get('limits'))
+            ep['locking'] = _ensure_list(ep.get('locking'))
+            ep['payouts_adjustments'] = _ensure_list(ep.get('payouts_adjustments'))
+            ep['payouts_groups'] = _ensure_list(ep.get('payouts_groups'))
+            ep['payout_restrictions'] = _ensure_list(ep.get('payout_restrictions'))
+            ep['payout_scheduling'] = _ensure_list(ep.get('payout_scheduling'))
+            ep['performance_bonus'] = _ensure_list(ep.get('performance_bonus'))
+            ep['valid_referrals'] = _ensure_list(ep.get('valid_referrals'))
+
+            # coerce nested int fields inside sub-arrays
+            for vr in ep.get('valid_referrals', []):
+                if isinstance(vr, dict):
+                    vr['window'] = _safe_int(vr.get('window'))
+
+            for lock in ep.get('locking', []):
+                if isinstance(lock, dict):
+                    lock['month_offset'] = _safe_int(lock.get('month_offset'))
+                    lock['day_offset'] = _safe_int(lock.get('day_offset'))
+
+            for ps in ep.get('payout_scheduling', []):
+                if isinstance(ps, dict):
+                    ps['day_offset'] = _safe_int(ps.get('day_offset'))
 
         record['template_terms'] = template_terms
     return this_json

--- a/tap_impact/transform.py
+++ b/tap_impact/transform.py
@@ -101,6 +101,7 @@ def _safe_int(value):
     try:
         return int(value)
     except (ValueError, TypeError):
+        LOGGER.warning('_safe_int: could not coerce %r to int, returning None', value)
         return None
 
 
@@ -113,6 +114,7 @@ def _safe_float(value):
     try:
         return float(value)
     except (ValueError, TypeError):
+        LOGGER.warning('_safe_float: could not coerce %r to float, returning None', value)
         return None
 
 

--- a/tap_impact/transform.py
+++ b/tap_impact/transform.py
@@ -130,17 +130,26 @@ def _ensure_list(value):
     return []
 
 
-# Transform contracts to fix type mismatches between the Impact API response
-# and the Singer schema.  The API returns many numeric values as strings and
-# single nested objects where the schema expects arrays.
+# Transform contracts to fix mismatches between the Impact API response
+# and the Singer schema.
 #
-# Without these coercions the Singer transformer silently drops the entire
-# events_payouts array because it fails strict schema validation.
+# Key issues:
+# 1. Field name mismatch: API returns "EventPayouts" which convert_json
+#    turns into "event_payouts", but schema expects "events_payouts".
+#    Same for "SpecialTermsList" -> "special_terms_list" (OK) and
+#    "PromotionalTerms" -> "promotional_terms" (not in schema).
+# 2. Type mismatches: API returns numerics as strings, single nested
+#    objects as dicts where schema expects arrays.
+# 3. additionalProperties: false means unrecognized fields cause drops.
 def transform_contracts(this_json, data_key):
     for record in this_json[data_key]:
         template_terms = record.get('template_terms')
         if not template_terms or not isinstance(template_terms, dict):
             continue
+
+        # --- fix field name: event_payouts -> events_payouts ---
+        if 'event_payouts' in template_terms and 'events_payouts' not in template_terms:
+            template_terms['events_payouts'] = template_terms.pop('event_payouts')
 
         # --- top-level template_terms: coerce string -> int/float ---
         template_terms['change_notification_period'] = _safe_int(

--- a/tap_impact/transform.py
+++ b/tap_impact/transform.py
@@ -92,14 +92,88 @@ def transform_conversion_paths(this_json, data_key):
     return this_json
 
 
+# Unwrap XML-style container objects into flat arrays.
+# The Impact API returns nested arrays wrapped in container objects, e.g.:
+#   "EventPayouts": {"EventPayout": [{...}, ...]}  (multiple items)
+#   "EventPayouts": {"EventPayout": {...}}          (single item as dict)
+# After camelCase conversion this becomes:
+#   "events_payouts": {"event_payout": [{...}, ...]}
+# But the schema expects events_payouts to be a flat array.
+def unwrap_container(value, singular_key):
+    """Unwrap a container object into a list.
+
+    Args:
+        value: The field value (could be list, dict-wrapper, or None).
+        singular_key: The snake_case singular key inside the wrapper dict.
+
+    Returns:
+        A list of items.
+    """
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, dict):
+        inner = value.get(singular_key, [])
+        if isinstance(inner, list):
+            return inner
+        elif isinstance(inner, dict):
+            return [inner]
+        return []
+    return []
+
+
+# Unwrap nested arrays in contract template_terms that use XML-style wrappers.
+# Affected fields: events_payouts, labels, special_terms_list, and nested arrays
+# within events_payouts items (limits, locking, payouts_adjustments, payouts_groups,
+# payout_restrictions, payout_scheduling, performance_bonus, valid_referrals).
+def transform_contracts(this_json, data_key):
+    for record in this_json[data_key]:
+        template_terms = record.get('template_terms')
+        if not template_terms or not isinstance(template_terms, dict):
+            continue
+
+        # Unwrap top-level arrays in template_terms
+        template_terms['events_payouts'] = unwrap_container(
+            template_terms.get('events_payouts'), 'event_payout')
+        template_terms['labels'] = unwrap_container(
+            template_terms.get('labels'), 'label')
+        template_terms['special_terms_list'] = unwrap_container(
+            template_terms.get('special_terms_list'), 'special_terms')
+
+        # Unwrap nested arrays within each event_payout item
+        for ep in template_terms.get('events_payouts', []):
+            if not isinstance(ep, dict):
+                continue
+            ep['limits'] = unwrap_container(ep.get('limits'), 'limit')
+            ep['locking'] = unwrap_container(ep.get('locking'), 'locking')
+            ep['payouts_adjustments'] = unwrap_container(
+                ep.get('payouts_adjustments'), 'payouts_adjustment')
+            ep['payouts_groups'] = unwrap_container(
+                ep.get('payouts_groups'), 'payouts_group')
+            ep['payout_restrictions'] = unwrap_container(
+                ep.get('payout_restrictions'), 'payout_restriction')
+            ep['payout_scheduling'] = unwrap_container(
+                ep.get('payout_scheduling'), 'payout_schedule')
+            ep['performance_bonus'] = unwrap_container(
+                ep.get('performance_bonus'), 'performance_bonus')
+            ep['valid_referrals'] = unwrap_container(
+                ep.get('valid_referrals'), 'valid_referral')
+
+        record['template_terms'] = template_terms
+    return this_json
+
+
 # Run all transforms: convert camelCase to snake_case for fieldname keys
 def transform_json(this_json, stream_name, data_key):
     converted_json = convert_json(this_json)
     converted_data_key = convert(data_key)
     if stream_name in ('actions', 'action_updates'):
         transformed_json = replace_order_id(converted_json, converted_data_key)[converted_data_key]
-    if stream_name in ['conversion_paths']:
+    elif stream_name in ['conversion_paths']:
         transformed_json = transform_conversion_paths(converted_json, converted_data_key)[converted_data_key]
+    elif stream_name == 'contracts':
+        transformed_json = transform_contracts(converted_json, converted_data_key)[converted_data_key]
     else:
         transformed_json = converted_json[converted_data_key]
     

--- a/tests/test_transform_contracts.py
+++ b/tests/test_transform_contracts.py
@@ -31,7 +31,7 @@ SAMPLE_API_RESPONSE = {
                 "labels": ["/affiliates page"],
                 "special_terms_list": None,
                 "promotional_terms": [{"some": "data"}],
-                "events_payouts": [
+                "event_payouts": [
                     {
                         "event_type_id": "57793",
                         "event_type_name": "Retained Full Price Shops: 6 Mo",

--- a/tests/test_transform_contracts.py
+++ b/tests/test_transform_contracts.py
@@ -1,0 +1,179 @@
+"""Tests for transform_contracts based on real Impact API response shapes."""
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from tap_impact.transform import transform_json
+
+# Real API response shape (after camelCase → snake_case via convert_json)
+SAMPLE_API_RESPONSE = {
+    "contracts": [
+        {
+            "id": "S-26838993",
+            "status": "A",
+            "template_terms": {
+                "change_notification_period": "1",
+                "currency": "USD",
+                "custom_creative_payer": "ADVERTISER",
+                "max_return_percentage": "100",
+                "name": "Public Terms",
+                "template_id": "351581",
+                "version_id": "810182",
+                "return_policy": "ALWAYS_OK",
+                "action_limit": None,
+                "action_limit_period": None,
+                "contract_start_slotting_fee": None,
+                "first_action_slotting_fee": None,
+                "min_earning_per_click": None,
+                "monthly_slotting_fee": None,
+                "spend_limit": None,
+                "spend_limit_period": None,
+                "labels": ["/affiliates page"],
+                "special_terms_list": None,
+                "promotional_terms": [{"some": "data"}],
+                "events_payouts": [
+                    {
+                        "event_type_id": "57793",
+                        "event_type_name": "Retained Full Price Shops: 6 Mo",
+                        "event_category": "SALE",
+                        "default_payout": "0.00",
+                        "default_payout_rate": None,
+                        "credit_policy": "PARENT_ACTION",
+                        "payout_level": "ITEM",
+                        "location_requirement_type": None,
+                        "location_requirement_countries": None,
+                        # Single dict where schema expects array
+                        "locking": {"basis": "TRACKED", "period": "MONTH",
+                                    "month_offset": "0", "day_offset": "21"},
+                        # Single dict where schema expects array
+                        "payout_scheduling": {"basis": "LOCKED", "period": "END_OF_DAY",
+                                              "day_offset": "1"},
+                        "valid_referrals": [
+                            {"type": "PARENT_ACTIONS", "window": "600", "window_unit": "DAY"}
+                        ],
+                        "limits": None,
+                        "payouts_adjustments": None,
+                        "payouts_groups": [
+                            {"id": "abc", "rank": "1", "rules": []}
+                        ],
+                        "payout_restrictions": None,
+                        "performance_bonus": None,
+                    }
+                ],
+            },
+        }
+    ]
+}
+
+
+def test_transform_contracts_type_coercion():
+    """Top-level template_terms string→int/float coercion."""
+    result = transform_json(SAMPLE_API_RESPONSE, 'contracts', 'Contracts')
+    tt = result[0]['template_terms']
+
+    assert tt['template_id'] == 351581, f"Expected int 351581, got {tt['template_id']!r}"
+    assert tt['version_id'] == 810182
+    assert tt['change_notification_period'] == 1
+    assert tt['max_return_percentage'] == 100.0
+    assert isinstance(tt['max_return_percentage'], float)
+    # None stays None
+    assert tt['action_limit'] is None
+    assert tt['spend_limit'] is None
+    print("  ✅ type coercion")
+
+
+def test_transform_contracts_events_payouts_preserved():
+    """events_payouts array should survive with coerced types."""
+    result = transform_json(SAMPLE_API_RESPONSE, 'contracts', 'Contracts')
+    tt = result[0]['template_terms']
+    ep = tt['events_payouts']
+
+    assert isinstance(ep, list), f"Expected list, got {type(ep)}"
+    assert len(ep) == 1, f"Expected 1 item, got {len(ep)}"
+
+    item = ep[0]
+    assert item['event_type_id'] == 57793, f"Expected int 57793, got {item['event_type_id']!r}"
+    assert item['default_payout'] == 0.0
+    assert isinstance(item['default_payout'], float)
+    print("  ✅ events_payouts preserved + coerced")
+
+
+def test_transform_contracts_dict_to_list():
+    """Single dict values should be wrapped in a list."""
+    result = transform_json(SAMPLE_API_RESPONSE, 'contracts', 'Contracts')
+    ep = result[0]['template_terms']['events_payouts'][0]
+
+    # locking was a dict, should now be [dict]
+    assert isinstance(ep['locking'], list), f"Expected list, got {type(ep['locking'])}"
+    assert len(ep['locking']) == 1
+    assert ep['locking'][0]['basis'] == 'TRACKED'
+    assert ep['locking'][0]['month_offset'] == 0  # coerced from "0"
+    assert ep['locking'][0]['day_offset'] == 21   # coerced from "21"
+
+    # payout_scheduling was a dict, should now be [dict]
+    assert isinstance(ep['payout_scheduling'], list)
+    assert len(ep['payout_scheduling']) == 1
+    assert ep['payout_scheduling'][0]['day_offset'] == 1
+    print("  ✅ dict→list wrapping + nested int coercion")
+
+
+def test_transform_contracts_valid_referrals():
+    """valid_referrals window should be coerced to int."""
+    result = transform_json(SAMPLE_API_RESPONSE, 'contracts', 'Contracts')
+    vr = result[0]['template_terms']['events_payouts'][0]['valid_referrals']
+
+    assert isinstance(vr, list)
+    assert vr[0]['window'] == 600, f"Expected int 600, got {vr[0]['window']!r}"
+    print("  ✅ valid_referrals window coerced")
+
+
+def test_transform_contracts_none_to_empty_list():
+    """None array fields should become []."""
+    result = transform_json(SAMPLE_API_RESPONSE, 'contracts', 'Contracts')
+    tt = result[0]['template_terms']
+    ep = tt['events_payouts'][0]
+
+    assert tt['special_terms_list'] == []
+    assert ep['limits'] == []
+    assert ep['payouts_adjustments'] == []
+    assert ep['payout_restrictions'] == []
+    assert ep['performance_bonus'] == []
+    print("  ✅ None→[] for array fields")
+
+
+def test_transform_contracts_drops_promotional_terms():
+    """promotional_terms not in schema, should be dropped."""
+    result = transform_json(SAMPLE_API_RESPONSE, 'contracts', 'Contracts')
+    tt = result[0]['template_terms']
+
+    assert 'promotional_terms' not in tt, "promotional_terms should be dropped"
+    print("  ✅ promotional_terms dropped")
+
+
+def test_transform_contracts_labels_passthrough():
+    """labels (simple string array) should pass through unchanged."""
+    result = transform_json(SAMPLE_API_RESPONSE, 'contracts', 'Contracts')
+    tt = result[0]['template_terms']
+
+    assert tt['labels'] == ["/affiliates page"]
+    print("  ✅ labels passthrough")
+
+
+def test_transform_contracts_extraction_date_added():
+    """extraction_date should be added to the record."""
+    result = transform_json(SAMPLE_API_RESPONSE, 'contracts', 'Contracts')
+    assert 'extraction_date' in result[0]
+    print("  ✅ extraction_date added")
+
+
+if __name__ == '__main__':
+    print("Running transform_contracts tests...")
+    test_transform_contracts_type_coercion()
+    test_transform_contracts_events_payouts_preserved()
+    test_transform_contracts_dict_to_list()
+    test_transform_contracts_valid_referrals()
+    test_transform_contracts_none_to_empty_list()
+    test_transform_contracts_drops_promotional_terms()
+    test_transform_contracts_labels_passthrough()
+    test_transform_contracts_extraction_date_added()
+    print("\n✅ All 8 tests passed!")


### PR DESCRIPTION
## What

Fixes contracts `events_payouts` data being silently dropped by Singer transformer. Needed for https://github.com/Shopify/data-warehouse/issues/46438

## Root Cause

Three issues between the Impact API response and the Singer schema:

### 1. Field name mismatch (PRIMARY)
`EventPayouts` → `convert_json()` → `event_payouts` — but schema expects `events_payouts` (with 's').
With `additionalProperties: false`, the field gets silently dropped → empty arrays for ALL contracts.

### 2. Type mismatches
API returns strings where schema expects numbers:
- `event_type_id: "57793"` (string → should be integer)
- `default_payout: "0.00"` (string → should be number)
- `window: "600"` (string → should be integer)

### 3. Dict vs array
API returns single objects as dicts where schema expects arrays:
- `Locking: {"Basis": "TRACKED", ...}` (dict → should be `[{...}]`)
- `PayoutScheduling: {"Basis": "LOCKED", ...}` (dict → should be `[{...}]`)

### 4. Extra field
API returns `PromotionalTerms` (not in schema) → triggers `additionalProperties: false` rejection.

## Fix

- `transform_contracts()`: renames `event_payouts` → `events_payouts`, coerces types, wraps dicts as lists, drops `promotional_terms`
- `_safe_int()` / `_safe_float()`: safe string → number coercion
- `_ensure_list()`: `None → []`, `dict → [dict]`, `list → list`
- Added to `transform_json()` dispatch for `contracts` stream

## Tests

8 unit tests in `tests/test_transform_contracts.py` covering:
- Type coercion (string → int/float, None passthrough)
- events_payouts preservation with correct types
- Dict→list wrapping for Locking/PayoutScheduling
- valid_referrals.window coercion
- None→[] for all array fields
- promotional_terms dropped
- labels passthrough
- extraction_date added

## Verified

Tested locally with real Impact API data — `events_payouts` survives transform with 4 items and correct types.