### PR TITLE
fix(contracts): rename payout_groups/payout_adjustments to plural schema names

### DIFF
--- a/tap_impact/transform.py
+++ b/tap_impact/transform.py
@@ -191,6 +191,15 @@ def transform_contracts(this_json, data_key):
             if not isinstance(ep, dict):
                 continue
 
+            # --- fix field names: API PayoutGroups/PayoutAdjustments
+            # convert to payout_groups/payout_adjustments, but schema
+            # expects payouts_groups/payouts_adjustments (same pattern
+            # as event_payouts -> events_payouts above).
+            if 'payout_groups' in ep and 'payouts_groups' not in ep:
+                ep['payouts_groups'] = ep.pop('payout_groups')
+            if 'payout_adjustments' in ep and 'payouts_adjustments' not in ep:
+                ep['payouts_adjustments'] = ep.pop('payout_adjustments')
+
             # string -> int / float coercions
             ep['event_type_id'] = _safe_int(ep.get('event_type_id'))
             ep['default_payout'] = _safe_float(ep.get('default_payout'))

--- a/tests/test_transform_contracts.py
+++ b/tests/test_transform_contracts.py
@@ -52,8 +52,14 @@ SAMPLE_API_RESPONSE = {
                             {"type": "PARENT_ACTIONS", "window": "600", "window_unit": "DAY"}
                         ],
                         "limits": None,
-                        "payouts_adjustments": None,
-                        "payouts_groups": [
+                        # NOTE: these keys (payout_adjustments / payout_groups, singular
+                        # "payout") are what convert_json() produces from the API's
+                        # PayoutAdjustments / PayoutGroups. The schema expects them
+                        # under payouts_adjustments / payouts_groups (plural "payouts").
+                        # Using the post-convert_json names here ensures the test would
+                        # catch a regression of the rename block in transform_contracts.
+                        "payout_adjustments": None,
+                        "payout_groups": [
                             {"id": "abc", "rank": "1", "rules": []}
                         ],
                         "payout_restrictions": None,
@@ -166,6 +172,28 @@ def test_transform_contracts_extraction_date_added():
     print("  ✅ extraction_date added")
 
 
+def test_transform_contracts_renames_payout_groups_and_adjustments():
+    """payout_groups/payout_adjustments (from convert_json) should be
+    renamed to payouts_groups/payouts_adjustments (schema names), with
+    data preserved. Regression test for the silent-data-loss bug where
+    PayoutGroups/PayoutAdjustments arrived empty in BigQuery."""
+    result = transform_json(SAMPLE_API_RESPONSE, 'contracts', 'Contracts')
+    ep = result[0]['template_terms']['events_payouts'][0]
+
+    # post-convert_json names should be gone
+    assert 'payout_groups' not in ep, "payout_groups should be renamed to payouts_groups"
+    assert 'payout_adjustments' not in ep, "payout_adjustments should be renamed to payouts_adjustments"
+
+    # schema names should hold the original data (not lost to additionalProperties: false)
+    assert isinstance(ep['payouts_groups'], list)
+    assert len(ep['payouts_groups']) == 1, f"Expected 1 payouts_groups entry, got {len(ep['payouts_groups'])}"
+    assert ep['payouts_groups'][0]['id'] == 'abc'
+
+    # payout_adjustments was None in fixture; should become [] after rename + _ensure_list
+    assert ep['payouts_adjustments'] == []
+    print("  ✅ payout_groups/payout_adjustments renamed to schema names")
+
+
 if __name__ == '__main__':
     print("Running transform_contracts tests...")
     test_transform_contracts_type_coercion()
@@ -176,4 +204,5 @@ if __name__ == '__main__':
     test_transform_contracts_drops_promotional_terms()
     test_transform_contracts_labels_passthrough()
     test_transform_contracts_extraction_date_added()
-    print("\n✅ All 8 tests passed!")
+    test_transform_contracts_renames_payout_groups_and_adjustments()
+    print("\n✅ All 9 tests passed!")


### PR DESCRIPTION
# Description of change

Fixes a second silent-data-loss bug in the contracts stream, same pattern as #19 (`event_payouts` → `events_payouts`). Needed for https://github.com/Shopify/data-warehouse/issues/46438 (Phase 1).

The Impact API returns `PayoutGroups` and `PayoutAdjustments` inside each event-payout entry. `convert_json()` lowercases them to `payout_groups` / `payout_adjustments`, but the schema expects `payouts_groups` / `payouts_adjustments` (plural "payouts"). With `additionalProperties: false` on the events_payouts items, the singular keys are stripped and the data is dropped before reaching BigQuery.

End-to-end verification against the production `account_sid` (full local sync — all 5 campaigns / 40,382 contracts):
- **PayoutGroups:** 38,368 / 282,597 events_payouts items carry real data (13.6%) — currently lost to the rename bug.
- **PayoutAdjustments:** the API does not return this field for our account today (0 / 20,968 sampled). The rename is effectively a no-op now, but kept for symmetry so the same regression doesn't silently recur if Impact starts returning it.

Code change is a 4-line rename inside `transform_contracts()`, mirroring the existing `event_payouts` → `events_payouts` block from #19.

# Manual QA steps
 - `python tests/test_transform_contracts.py` — 9 tests pass (includes new `test_transform_contracts_renames_payout_groups_and_adjustments` regression test).
 - Local full-account sync against prod `account_sid`: `payouts_groups` is now populated with real nested data instead of empty arrays.
 - Pre/post schema-violation delta against `contracts.json`: 0 new violations introduced.
 - After merge: bump `pip_url` SHA in the `data-warehouse` Meltano config (`tap_impact.yml`) and run staging E2E into `shopify-stg-dw.raw_impact.contracts`; confirm `payouts_groups` is populated and `payouts_adjustments` is still `[]` (expected — API doesn't return it).

# Risks
 - Low. Pure rename of keys that are already being silently dropped — no schema change, no new fields, no API behavior change. Pre-existing strict-schema violations are identical pre/post (verified by diff).
 - Downstream consumers reading `contracts.template_terms.events_payouts[].payouts_groups` will see populated arrays where they previously saw `[]`. That's a correction, not a regression, but worth flagging if any model is asserting emptiness as truth.

# Rollback steps
 - Revert this branch in `Shopify/tap-impact`, then revert the `pip_url` SHA bump in the `data-warehouse` Meltano config (`areas/batch-processing/data-warehouse/meltano/data_warehouse/subconfigs/marketing/third_party_performance/tap_impact.yml`).