### PR TITLE
05 18 part 2 dropped data

### DIFF
--- a/tap_impact/schemas/contracts.json
+++ b/tap_impact/schemas/contracts.json
@@ -62,7 +62,7 @@
         },
         "contract_start_slotting_fee": {
           "type": ["null", "number"],
-          "multipleOf": 1e-8
+          "multipleOf": 1e-08
         },
         "currency": {
           "type": ["null", "string"]
@@ -83,11 +83,11 @@
                   },
                   "default_payout": {
                     "type": ["null", "number"],
-                    "multipleOf": 1e-8
+                    "multipleOf": 1e-08
                   },
                   "default_payout_rate": {
                     "type": ["null", "number"],
-                    "multipleOf": 1e-8
+                    "multipleOf": 1e-08
                   },
                   "event_category": {
                     "type": ["null", "string"]
@@ -103,29 +103,7 @@
                       {
                         "type": "array",
                         "items": {
-                          "type": "object",
-                          "additionalProperties": false,
-                          "properties": {
-                            "limit_by": {
-                              "type": ["null", "string"]
-                            },
-                            "period": {
-                              "type": ["null", "string"]
-                            },
-                            "type": {
-                              "type": ["null", "string"]
-                            },
-                            "subtype": {
-                              "type": ["null", "string"]
-                            },
-                            "value": {
-                              "type": ["null", "number"],
-                              "multipleOf": 1e-8
-                            },
-                            "weekend_override_value": {
-                              "type": ["null", "integer"]
-                            }
-                          }
+                          "type": "object"
                         }
                       },
                       {
@@ -144,31 +122,7 @@
                       {
                         "type": "array",
                         "items": {
-                          "type": "object",
-                          "additionalProperties": false,
-                          "properties": {
-                            "basis": {
-                              "type": ["null", "string"]
-                            },
-                            "day_of_month": {
-                              "type": ["null", "integer"]
-                            },
-                            "day_offset": {
-                              "type": ["null", "integer"]
-                            },
-                            "max_months_open_ended_period": {
-                              "type": ["null", "integer"]
-                            },
-                            "month_offset": {
-                              "type": ["null", "integer"]
-                            },
-                            "open_ended_autolocking_mode": {
-                              "type": ["null", "string"]
-                            },
-                            "period": {
-                              "type": ["null", "string"]
-                            }
-                          }
+                          "type": "object"
                         }
                       },
                       {
@@ -181,58 +135,7 @@
                       {
                         "type": "array",
                         "items": {
-                          "type": "object",
-                          "additionalProperties": false,
-                          "properties": {
-                            "amount": {
-                              "type": ["null", "number"],
-                              "multipleOf": 1e-8
-                            },
-                            "direction": {
-                              "type": ["null", "string"]
-                            },
-                            "id": {
-                              "type": ["null", "string"]
-                            },
-                            "rate": {
-                              "type": ["null", "integer"]
-                            },
-                            "rules": {
-                              "anyOf": [
-                                {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "operator": {
-                                        "type": ["null", "string"]
-                                      },
-                                      "variable": {
-                                        "type": ["null", "string"]
-                                      },
-                                      "values": {
-                                        "anyOf": [
-                                          {
-                                            "type": "array",
-                                            "items": {
-                                              "type": "object"
-                                            }
-                                          },
-                                          {
-                                            "type": ["null", "string"]
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  }
-                                },
-                                {
-                                  "type": "null"
-                                }
-                              ]
-                            }
-                          }
+                          "type": "object"
                         }
                       },
                       {
@@ -245,127 +148,7 @@
                       {
                         "type": "array",
                         "items": {
-                          "type": "object",
-                          "additionalProperties": false,
-                          "properties": {
-                            "id": {
-                              "type": ["null", "string"]
-                            },
-                            "limits": {
-                              "anyOf": [
-                                {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "limit_by": {
-                                        "type": ["null", "string"]
-                                      },
-                                      "period": {
-                                        "type": ["null", "string"]
-                                      },
-                                      "type": {
-                                        "type": ["null", "string"]
-                                      },
-                                      "subtype": {
-                                        "type": ["null", "string"]
-                                      },
-                                      "value": {
-                                        "type": ["null", "number"],
-                                        "multipleOf": 1e-8
-                                      },
-                                      "weekend_override_value": {
-                                        "type": ["null", "integer"]
-                                      }
-                                    }
-                                  }
-                                },
-                                {
-                                  "type": "null"
-                                }
-                              ]
-                            },
-                            "payout": {
-                              "type": ["null", "number"],
-                              "multipleOf": 1e-8
-                            },
-                            "payout_rate": {
-                              "type": ["null", "integer"]
-                            },
-                            "rank": {
-                              "type": ["null", "integer"]
-                            },
-                            "rules": {
-                              "anyOf": [
-                                {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "operator": {
-                                        "type": ["null", "string"]
-                                      },
-                                      "variable": {
-                                        "type": ["null", "string"]
-                                      },
-                                      "values": {
-                                        "anyOf": [
-                                          {
-                                            "type": "array",
-                                            "items": {
-                                              "type": "object"
-                                            }
-                                          },
-                                          {
-                                            "type": ["null", "string"]
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  }
-                                },
-                                {
-                                  "type": "null"
-                                }
-                              ]
-                            },
-                            "tiers": {
-                              "anyOf": [
-                                {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "action_threshold": {
-                                        "type": ["null", "integer"]
-                                      },
-                                      "parent_tier": {
-                                        "type": ["null", "integer"]
-                                      },
-                                      "payout": {
-                                        "type": ["null", "number"],
-                                        "multipleOf": 1e-8
-                                      },
-                                      "payout_rate": {
-                                        "type": ["null", "number"],
-                                        "multipleOf": 1e-8
-                                      },
-                                      "revenue_threshold": {
-                                        "type": ["null", "number"],
-                                        "multipleOf": 1e-8
-                                      }
-                                    }
-                                  }
-                                },
-                                {
-                                  "type": "null"
-                                }
-                              ]
-                            }
-                          }
+                          "type": "object"
                         }
                       },
                       {
@@ -381,48 +164,7 @@
                       {
                         "type": "array",
                         "items": {
-                          "type": "object",
-                          "additionalProperties": false,
-                          "properties": {
-                            "id": {
-                              "type": ["null", "string"]
-                            },
-                            "rules": {
-                              "anyOf": [
-                                {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "operator": {
-                                        "type": ["null", "string"]
-                                      },
-                                      "variable": {
-                                        "type": ["null", "string"]
-                                      },
-                                      "values": {
-                                        "anyOf": [
-                                          {
-                                            "type": "array",
-                                            "items": {
-                                              "type": "object"
-                                            }
-                                          },
-                                          {
-                                            "type": ["null", "string"]
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  }
-                                },
-                                {
-                                  "type": "null"
-                                }
-                              ]
-                            }
-                          }
+                          "type": "object"
                         }
                       },
                       {
@@ -435,22 +177,7 @@
                       {
                         "type": "array",
                         "items": {
-                          "type": "object",
-                          "additionalProperties": false,
-                          "properties": {
-                            "basis": {
-                              "type": ["null", "string"]
-                            },
-                            "day_offset": {
-                              "type": ["null", "integer"]
-                            },
-                            "month_offset": {
-                              "type": ["null", "integer"]
-                            },
-                            "period": {
-                              "type": ["null", "string"]
-                            }
-                          }
+                          "type": "object"
                         }
                       },
                       {
@@ -463,50 +190,7 @@
                       {
                         "type": "array",
                         "items": {
-                          "type": "object",
-                          "additionalProperties": false,
-                          "properties": {
-                            "basis": {
-                              "type": ["null", "string"]
-                            },
-                            "bonus_tiers": {
-                              "anyOf": [
-                                {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "action_threshold": {
-                                        "type": ["null", "integer"]
-                                      },
-                                      "payout": {
-                                        "type": ["null", "number"],
-                                        "multipleOf": 1e-8
-                                      },
-                                      "payout_rate": {
-                                        "type": ["null", "number"],
-                                        "multipleOf": 1e-8
-                                      },
-                                      "revenue_threshold": {
-                                        "type": ["null", "number"],
-                                        "multipleOf": 1e-8
-                                      }
-                                    }
-                                  }
-                                },
-                                {
-                                  "type": "null"
-                                }
-                              ]
-                            },
-                            "period": {
-                              "type": ["null", "string"]
-                            },
-                            "type": {
-                              "type": ["null", "string"]
-                            }
-                          }
+                          "type": "object"
                         }
                       },
                       {
@@ -519,19 +203,7 @@
                       {
                         "type": "array",
                         "items": {
-                          "type": "object",
-                          "additionalProperties": false,
-                          "properties": {
-                            "type": {
-                              "type": ["null", "string"]
-                            },
-                            "window": {
-                              "type": ["null", "integer"]
-                            },
-                            "window_unit": {
-                              "type": ["null", "string"]
-                            }
-                          }
+                          "type": "object"
                         }
                       },
                       {
@@ -549,7 +221,7 @@
         },
         "first_action_slotting_fee": {
           "type": ["null", "number"],
-          "multipleOf": 1e-8
+          "multipleOf": 1e-08
         },
         "labels": {
           "anyOf": [
@@ -566,15 +238,15 @@
         },
         "max_return_percentage": {
           "type": ["null", "number"],
-          "multipleOf": 1e-8
+          "multipleOf": 1e-08
         },
         "min_earning_per_click": {
           "type": ["null", "number"],
-          "multipleOf": 1e-8
+          "multipleOf": 1e-08
         },
         "monthly_slotting_fee": {
           "type": ["null", "number"],
-          "multipleOf": 1e-8
+          "multipleOf": 1e-08
         },
         "name": {
           "type": ["null", "string"]
@@ -610,9 +282,35 @@
             }
           ]
         },
+        "promotional_terms": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cpc_payouts": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "spend_limit": {
           "type": ["null", "number"],
-          "multipleOf": 1e-8
+          "multipleOf": 1e-08
         },
         "spend_limit_period": {
           "type": ["null", "string"]
@@ -627,6 +325,28 @@
     },
     "uri": {
       "type": ["null", "string"]
+    },
+    "campaign_id": {
+      "type": ["null", "integer"]
+    },
+    "campaign_name": {
+      "type": ["null", "string"]
+    },
+    "has_campaign_terms": {
+      "type": ["null", "string"]
+    },
+    "zero_payout_hide_report": {
+      "type": ["null", "string"]
+    },
+    "scheduled_terms": {
+      "type": ["null", "object"],
+      "additionalProperties": false,
+      "properties": {
+        "effective_date": {
+          "type": ["null", "string"],
+          "format": "date-time"
+        }
+      }
     },
     "extraction_date": {
       "type": ["null", "string"],

--- a/tap_impact/transform.py
+++ b/tap_impact/transform.py
@@ -133,18 +133,13 @@ def _ensure_list(value):
 
 
 # Transform contracts to fix mismatches between the Impact API response
-# and the Singer schema.
-#
-# Key issues:
-# 1. Field name mismatch: API returns "EventPayouts" which convert_json
-#    turns into "event_payouts", but schema expects "events_payouts".
-#    Same for "SpecialTermsList" -> "special_terms_list" (OK) and
-#    "PromotionalTerms" -> "promotional_terms" (not in schema).
-# 2. Type mismatches: API returns numerics as strings, single nested
-#    objects as dicts where schema expects arrays.
-# 3. additionalProperties: false means unrecognized fields cause drops.
+# and the Singer schema. Fixes field-name skew, coerces string numerics,
+# and normalizes "single dict where schema expects array" cases.
 def transform_contracts(this_json, data_key):
     for record in this_json[data_key]:
+        # --- contract-level: coerce campaign_id string -> int ---
+        record['campaign_id'] = _safe_int(record.get('campaign_id'))
+
         template_terms = record.get('template_terms')
         if not template_terms or not isinstance(template_terms, dict):
             continue
@@ -182,9 +177,10 @@ def transform_contracts(this_json, data_key):
             template_terms.get('labels'))
         template_terms['special_terms_list'] = _ensure_list(
             template_terms.get('special_terms_list'))
-
-        # --- drop fields not in schema (additionalProperties: false) ---
-        template_terms.pop('promotional_terms', None)
+        template_terms['promotional_terms'] = _ensure_list(
+            template_terms.get('promotional_terms'))
+        template_terms['cpc_payouts'] = _ensure_list(
+            template_terms.get('cpc_payouts'))
 
         # --- events_payouts items: coerce types + ensure nested arrays ---
         for ep in template_terms.get('events_payouts', []):

--- a/tests/test_transform_contracts.py
+++ b/tests/test_transform_contracts.py
@@ -11,7 +11,7 @@ SAMPLE_API_RESPONSE = {
         {
             "id": "S-26838993",
             "status": "A",
-            # --- contract-level fields (Phase 2 — Gary's ask) ---
+            # --- contract-level fields added in Phase 2 ---
             "campaign_id": "99999",
             "campaign_name": "Shopify Affiliate Program",
             "has_campaign_terms": "true",
@@ -42,7 +42,7 @@ SAMPLE_API_RESPONSE = {
                      "terms_pdf_uri": "https://example.com/promo.pdf",
                      "terms_type": "STANDARD"}
                 ],
-                # --- cpc_payouts forward-compat (Gary's ask) ---
+                # --- cpc_payouts forward-compat ---
                 "cpc_payouts": [{"event_type_id": "1234", "rate": "0.25"}],
                 "event_payouts": [
                     {
@@ -228,12 +228,12 @@ def test_transform_contracts_extraction_date_added():
 
 
 def test_transform_contracts_unknown_nested_fields_ride_through():
-    """Gary's [ALL CHILD ATTRIBUTES] ask: unknown sub-fields inside the
-    8 sub-arrays under events_payouts[] (payouts_groups, payouts_adjustments,
-    payout_restrictions, payout_scheduling, performance_bonus, limits,
-    locking, valid_referrals) + promotional_terms[] should survive the
-    Singer Transformer roundtrip, since those nested item schemas are now
-    opaque {type: object} instead of strict-with-properties.
+    """Unknown sub-fields inside the 8 sub-arrays under events_payouts[]
+    (payouts_groups, payouts_adjustments, payout_restrictions,
+    payout_scheduling, performance_bonus, limits, locking, valid_referrals)
+    + promotional_terms[] should survive the Singer Transformer roundtrip,
+    since those nested item schemas are now opaque {type: object} instead
+    of strict-with-properties.
 
     Regression test for the dropped-data class of bug Phase 2 closes:
     future Impact API additions inside these sub-arrays must land in BQ."""

--- a/tests/test_transform_contracts.py
+++ b/tests/test_transform_contracts.py
@@ -11,6 +11,12 @@ SAMPLE_API_RESPONSE = {
         {
             "id": "S-26838993",
             "status": "A",
+            # --- contract-level fields (Phase 2 — Gary's ask) ---
+            "campaign_id": "99999",
+            "campaign_name": "Shopify Affiliate Program",
+            "has_campaign_terms": "true",
+            "zero_payout_hide_report": "false",
+            "scheduled_terms": {"effective_date": "2026-01-01T00:00:00Z"},
             "template_terms": {
                 "change_notification_period": "1",
                 "currency": "USD",
@@ -30,7 +36,14 @@ SAMPLE_API_RESPONSE = {
                 "spend_limit_period": None,
                 "labels": ["/affiliates page"],
                 "special_terms_list": None,
-                "promotional_terms": [{"some": "data"}],
+                # --- promotional_terms now preserved, not dropped (Phase 2) ---
+                "promotional_terms": [
+                    {"terms_name": "Holiday Promo",
+                     "terms_pdf_uri": "https://example.com/promo.pdf",
+                     "terms_type": "STANDARD"}
+                ],
+                # --- cpc_payouts forward-compat (Gary's ask) ---
+                "cpc_payouts": [{"event_type_id": "1234", "rate": "0.25"}],
                 "event_payouts": [
                     {
                         "event_type_id": "57793",
@@ -62,7 +75,11 @@ SAMPLE_API_RESPONSE = {
                         "payout_groups": [
                             {"id": "abc", "rank": "1", "rules": []}
                         ],
-                        "payout_restrictions": None,
+                        # payout_restrictions now exercises the new nested
+                        # zero_payout_hide_report field (Phase 2).
+                        "payout_restrictions": [
+                            {"id": "pr-1", "zero_payout_hide_report": "1", "rules": []}
+                        ],
                         "performance_bonus": None,
                     }
                 ],
@@ -142,18 +159,56 @@ def test_transform_contracts_none_to_empty_list():
     assert tt['special_terms_list'] == []
     assert ep['limits'] == []
     assert ep['payouts_adjustments'] == []
-    assert ep['payout_restrictions'] == []
     assert ep['performance_bonus'] == []
     print("  ✅ None→[] for array fields")
 
 
-def test_transform_contracts_drops_promotional_terms():
-    """promotional_terms not in schema, should be dropped."""
+def test_transform_contracts_preserves_promotional_terms():
+    """promotional_terms now declared in schema, should survive transform
+    (regression test — was being explicitly .pop()'d before Phase 2)."""
     result = transform_json(SAMPLE_API_RESPONSE, 'contracts', 'Contracts')
     tt = result[0]['template_terms']
 
-    assert 'promotional_terms' not in tt, "promotional_terms should be dropped"
-    print("  ✅ promotional_terms dropped")
+    assert 'promotional_terms' in tt, "promotional_terms should be preserved"
+    assert isinstance(tt['promotional_terms'], list)
+    assert tt['promotional_terms'][0]['terms_name'] == 'Holiday Promo'
+    assert tt['promotional_terms'][0]['terms_type'] == 'STANDARD'
+    # cpc_payouts also forward-compat preserved
+    assert isinstance(tt['cpc_payouts'], list)
+    assert tt['cpc_payouts'][0]['event_type_id'] == '1234'
+    print("  ✅ promotional_terms + cpc_payouts preserved")
+
+
+def test_transform_contracts_new_contract_level_fields():
+    """5 contract-level fields added in Phase 2 should survive transform."""
+    result = transform_json(SAMPLE_API_RESPONSE, 'contracts', 'Contracts')
+    record = result[0]
+
+    # campaign_id coerced from "99999" -> 99999
+    assert record['campaign_id'] == 99999, f"Expected int 99999, got {record['campaign_id']!r}"
+    assert isinstance(record['campaign_id'], int)
+
+    # string passthroughs
+    assert record['campaign_name'] == 'Shopify Affiliate Program'
+    assert record['has_campaign_terms'] == 'true'
+    assert record['zero_payout_hide_report'] == 'false'
+
+    # scheduled_terms is an object — survives untouched
+    assert isinstance(record['scheduled_terms'], dict)
+    assert record['scheduled_terms']['effective_date'] == '2026-01-01T00:00:00Z'
+    print("  ✅ 5 contract-level fields preserved + campaign_id coerced")
+
+
+def test_transform_contracts_payout_restrictions_nested_field():
+    """zero_payout_hide_report nested inside payout_restrictions[] should
+    survive transform (Phase 2 — newly declared in schema)."""
+    result = transform_json(SAMPLE_API_RESPONSE, 'contracts', 'Contracts')
+    pr = result[0]['template_terms']['events_payouts'][0]['payout_restrictions']
+
+    assert isinstance(pr, list) and len(pr) == 1
+    assert pr[0]['id'] == 'pr-1'
+    assert pr[0]['zero_payout_hide_report'] == '1'
+    print("  ✅ payout_restrictions[].zero_payout_hide_report preserved")
 
 
 def test_transform_contracts_labels_passthrough():
@@ -170,6 +225,61 @@ def test_transform_contracts_extraction_date_added():
     result = transform_json(SAMPLE_API_RESPONSE, 'contracts', 'Contracts')
     assert 'extraction_date' in result[0]
     print("  ✅ extraction_date added")
+
+
+def test_transform_contracts_unknown_nested_fields_ride_through():
+    """Gary's [ALL CHILD ATTRIBUTES] ask: unknown sub-fields inside the
+    8 sub-arrays under events_payouts[] (payouts_groups, payouts_adjustments,
+    payout_restrictions, payout_scheduling, performance_bonus, limits,
+    locking, valid_referrals) + promotional_terms[] should survive the
+    Singer Transformer roundtrip, since those nested item schemas are now
+    opaque {type: object} instead of strict-with-properties.
+
+    Regression test for the dropped-data class of bug Phase 2 closes:
+    future Impact API additions inside these sub-arrays must land in BQ."""
+    import json, os
+    from singer.transform import Transformer
+
+    schema_path = os.path.join(os.path.dirname(__file__), '..',
+                               'tap_impact', 'schemas', 'contracts.json')
+    schema = json.load(open(schema_path))
+
+    # Synthetic record with unknown sub-fields planted inside opaque containers.
+    # CamelCase intentionally — mimics the real API shape pre-convert_json.
+    synthetic = {
+        "Contracts": [{
+            "Id": "ride-through-test",
+            "TemplateTerms": {
+                "EventPayouts": [{
+                    "EventTypeId": "1",
+                    "PayoutGroups": [{
+                        "Id": "pg-1",
+                        "FutureImpactField": "should survive",
+                        "DeepArray": [{"x": 1}]
+                    }],
+                    "Locking": {"basis": "TRACKED", "future_locking_field": "new"},
+                    "ValidReferrals": [{"type": "X", "brand_new_field": "v"}]
+                }]
+            }
+        }]
+    }
+
+    records = transform_json(synthetic, 'contracts', 'Contracts')
+    out = Transformer().transform(records[0], schema)
+    ep = out['template_terms']['events_payouts'][0]
+
+    pg = ep['payouts_groups'][0]
+    assert pg['future_impact_field'] == 'should survive', \
+        f"Unknown nested field dropped — opacify regressed. Got: {pg}"
+    assert pg['deep_array'] == [{'x': 1}]
+
+    lock = ep['locking'][0]
+    assert lock['future_locking_field'] == 'new'
+
+    vr = ep['valid_referrals'][0]
+    assert vr['brand_new_field'] == 'v'
+
+    print("  ✅ unknown nested fields ride through opaque sub-array items")
 
 
 def test_transform_contracts_renames_payout_groups_and_adjustments():
@@ -201,8 +311,11 @@ if __name__ == '__main__':
     test_transform_contracts_dict_to_list()
     test_transform_contracts_valid_referrals()
     test_transform_contracts_none_to_empty_list()
-    test_transform_contracts_drops_promotional_terms()
+    test_transform_contracts_preserves_promotional_terms()
+    test_transform_contracts_new_contract_level_fields()
+    test_transform_contracts_payout_restrictions_nested_field()
     test_transform_contracts_labels_passthrough()
     test_transform_contracts_extraction_date_added()
+    test_transform_contracts_unknown_nested_fields_ride_through()
     test_transform_contracts_renames_payout_groups_and_adjustments()
-    print("\n✅ All 9 tests passed!")
+    print("\n✅ All 12 tests passed!")


### PR DESCRIPTION
# Description of change

Recovers contract-level fields the Impact API returns but the Singer schema was silently dropping.

**Two changes:**
1. **Add 7 explicit schema entries** — 5 contract-root (`campaign_id`, `campaign_name`, `has_campaign_terms`, `zero_payout_hide_report`, `scheduled_terms`) + 2 under `template_terms` (`promotional_terms`, `cpc_payouts`). Also removes the transform-level `.pop('promotional_terms')` that was discarding the field.
2. **Opacify 8 nested array-item schemas** under `events_payouts[]` (`payouts_groups`, `payouts_adjustments`, `payout_restrictions`, `payout_scheduling`, `performance_bonus`, `limits`, `locking`, `valid_referrals`) + `promotional_terms[]`. These already land in BQ as `REPEATED JSON`; making their Singer item schemas `{type: object}` lets the child fields ride through the Transformer instead of being filtered out.

# Manual QA steps

Local sync against the prod-pinned `account_sid` (contracts + campaigns streams only):
- 42,660 contracts synced, all HTTP 200s, zero schema warnings
- `campaign_id`: 100% populated (42,660 / 42,660)
- `promotional_terms`: 0% → 99.98% (recovered; was being `.pop()`'d)
- Sub-array child keys now landing through opacified items: `locking` (basis, period, month_offset, day_offset) on 298K items; `payout_scheduling` on 298K; `valid_referrals` (type, window, window_unit) on 298K; `payout_restrictions` (id, rules, zero_payout_hide_report) on 170K; `payouts_groups` (id, rank, rules, payout, payout_rate) on 81K; `performance_bonus` on 2.5K
- 12/12 unit tests pass, including a regression test that plants unknown sub-fields inside every opaque sub-array and asserts they survive the Transformer roundtrip

# Risks

- New BQ columns (NULLABLE, additive): 5 contract-root + 2 nested REPEATED JSON columns.
- \`promotional_terms\` goes from 0% → 99.98% populated — any downstream view that special-cases NULL there will see fewer matches (intended; was data loss before).
- No DDL change for the 8 already-existing REPEATED JSON sub-arrays; child keys now ride through their existing JSON blobs.