### PR TITLE
Add Status param to contracts stream to capture non-ACTIVE contracts

### DIFF
--- a/tap_impact/streams.py
+++ b/tap_impact/streams.py
@@ -103,7 +103,15 @@ STREAMS = {
                 'key_properties': ['id'],
                 'page_size': 20000,
                 'replication_method': 'FULL_TABLE',
-                'parent': 'campaign'
+                'parent': 'campaign',
+                # Without Status, the API defaults to ACTIVE-only and silently drops
+                # non-ACTIVE contracts. The RestContractStatus enum accepts exactly:
+                # ACTIVE, EXPIRED, PENDING, UPCOMING, DECLINED (verified against
+                # api.impact.com 2026-05-20). DECLINED is excluded intentionally as it
+                # represents partner-rejected proposals that never went live.
+                'params': {
+                    'Status': 'ACTIVE,EXPIRED,PENDING,UPCOMING'
+                }
             },
             'conversion_paths': {
                 'path': 'Campaigns/{}/Models/<model_id>/ConversionPaths',

--- a/tests/test_streams_contracts_params.py
+++ b/tests/test_streams_contracts_params.py
@@ -1,0 +1,58 @@
+"""Pins the contracts stream's Status param to the values verified against
+api.impact.com on 2026-05-20.
+
+Without Status, the Impact API defaults to ACTIVE-only, silently dropping
+EXPIRED, PENDING, and UPCOMING contracts. The RestContractStatus enum accepts
+exactly 5 values: ACTIVE, EXPIRED, PENDING, UPCOMING, DECLINED. DECLINED is
+intentionally excluded as it represents partner-rejected proposals that never
+went live.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from tap_impact.streams import STREAMS
+
+
+VALID_STATES = {'ACTIVE', 'EXPIRED', 'PENDING', 'UPCOMING'}
+DECLINED_INTENTIONALLY_EXCLUDED = {'DECLINED'}
+INVALID_ENUM_VALUES = {'SCHEDULED', 'TERMINATED', 'INACTIVE', 'ALL', 'ANY'}
+
+
+def _contracts_config():
+    return STREAMS['campaigns']['children']['contracts']
+
+
+def test_contracts_stream_passes_status_param():
+    params = _contracts_config().get('params', {})
+    assert 'Status' in params, (
+        "contracts stream must pass Status param; without it the Impact API "
+        "defaults to ACTIVE-only and drops EXPIRED + PENDING + UPCOMING contracts."
+    )
+
+
+def test_contracts_status_param_includes_all_required_states():
+    values = {s.strip() for s in _contracts_config()['params']['Status'].split(',')}
+    assert values == VALID_STATES, (
+        f"Status must be exactly {VALID_STATES}; got {values}. "
+        f"These are the 4 RestContractStatus enum values that should land in BQ — "
+        f"DECLINED is the 5th valid value but is intentionally excluded as rejection-noise."
+    )
+
+
+def test_contracts_status_param_excludes_declined():
+    values = {s.strip() for s in _contracts_config()['params']['Status'].split(',')}
+    assert not (values & DECLINED_INTENTIONALLY_EXCLUDED), (
+        "DECLINED is intentionally excluded — partner-rejected proposals that "
+        "never went live; revisit if rejection-pipeline visibility is needed."
+    )
+
+
+def test_contracts_status_param_excludes_invalid_enum_values():
+    values = {s.strip() for s in _contracts_config()['params']['Status'].split(',')}
+    bad = values & INVALID_ENUM_VALUES
+    assert not bad, (
+        f"Status must not include {bad} — these raise a RestContractStatus binding "
+        f"error from the API."
+    )


### PR DESCRIPTION
# Description of change

Adds a `Status` query parameter to the contracts endpoint to surface non-ACTIVE contracts. Without the param, the Impact API defaults to ACTIVE-only and silently drops `EXPIRED`, `PENDING`, and `UPCOMING` contracts.

The `RestContractStatus` enum accepts 5 values; this PR opts into 4: `ACTIVE,EXPIRED,PENDING,UPCOMING`. `DECLINED` is intentionally excluded (partner-rejected proposals that never went live).

Note: the param name is `Status`, not `ContractStatus` as the public API reference implies (verified directly against `api.impact.com`). Multi-value syntax is comma-separated; repeated-key form is rejected by the API.

# Manual QA steps

- Run `pytest tests/` — 16/16 green (12 pre-existing + 4 new param tests pinning the param shape, value set, and explicit `DECLINED` exclusion)
- Invoke the tap against a test account and confirm contract records emit with mixed `status` values (not just `ACTIVE`)

# Risks

- The Impact API caps response page size at 1,000 records regardless of `PageSize`. Contract syncs that previously returned only ACTIVE rows will take proportionally longer once non-ACTIVE rows are included.
- Downstream consumers that implicitly assume the contracts table is ACTIVE-only will see rows with `status != 'ACTIVE'` — coordinate the downstream rollout.

# Rollback steps

- revert this branch