### PR TITLE
Change work_phone_number schema type from integer to string

### DIFF
--- a/tap_impact/schemas/contacts.json
+++ b/tap_impact/schemas/contacts.json
@@ -71,7 +71,7 @@
       "type": ["null", "string"]
     },
     "work_phone_number": {
-      "type": ["null", "integer"]
+      "type": ["null", "string"]
     },
     "work_phone_number_country": {
       "type": ["null", "string"]


### PR DESCRIPTION
## Summary

part of issue : https://github.com/Shopify/data-warehouse/issues/50057
- Change the `work_phone_number` field type in `contacts.json` from `integer` to `string`.

Phone numbers are better represented as strings — they can contain leading zeros, formatting, and country prefixes that an integer type cannot preserve.

## Change
```diff
 "work_phone_number": {
-  "type": ["null", "integer"]
+  "type": ["null", "string"]
 }
```


Tested that this worked on staging with this data-warehouse work: https://github.com/Shopify/data-warehouse/pull/50236 will update hash once this merges 

🤖 Generated with [Claude Code](https://claude.com/claude-code)